### PR TITLE
단체 생성 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/CreateOrganizationRequest.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/CreateOrganizationRequest.kt
@@ -1,0 +1,33 @@
+package com.yourssu.openssupot.application.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.CreateOrganizationCommand
+import jakarta.validation.constraints.NotEmpty
+import org.springframework.web.multipart.MultipartFile
+
+data class CreateOrganizationRequest(
+
+    @NotEmpty(message = "이메일이 입력되지 않았습니다.")
+    val email: String,
+
+    @NotEmpty(message = "비밀번호가 입력되지 않았습니다.")
+    val password: String,
+
+    @NotEmpty(message = "단체 이름이 입력되지 않았습니다.")
+    val name: String,
+
+    val description: String? = null,
+
+    @NotEmpty(message = "예약 비밀번호가 입력되지 않았습니다.")
+    val reservationPassword: String,
+) {
+    fun toCommand(logoImage: MultipartFile?): CreateOrganizationCommand {
+        return CreateOrganizationCommand(
+            email = email,
+            rawPassword = password,
+            name = name,
+            logoImage = logoImage,
+            description = description,
+            rawReservationPassword = reservationPassword,
+        )
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/OrganizationController.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/OrganizationController.kt
@@ -1,0 +1,28 @@
+package com.yourssu.openssupot.application.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.OrganizationService
+import jakarta.validation.Valid
+import java.net.URI
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/organizations")
+class OrganizationController(
+    private val organizationService: OrganizationService
+) {
+
+    @PostMapping
+    fun create(
+        @RequestPart(required = false) image: MultipartFile?,
+        @RequestPart @Valid request: CreateOrganizationRequest,
+    ) : ResponseEntity<Unit> {
+        val organizationId = organizationService.create(request.toCommand(image))
+
+        return ResponseEntity.created(URI.create("/organizations/$organizationId")).build()
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/application/support/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/support/exception/GlobalExceptionHandler.kt
@@ -4,6 +4,13 @@ import com.yourssu.openssupot.domain.domain.file.InvalidFileException
 import com.yourssu.openssupot.domain.domain.file.ReadFailureException
 import com.yourssu.openssupot.domain.domain.file.StoreFailureException
 import com.yourssu.openssupot.domain.domain.file.UnsupportedFileExtensionException
+import com.yourssu.openssupot.domain.domain.organization.DuplicateEmailException
+import com.yourssu.openssupot.domain.domain.organization.InvalidEmailException
+import com.yourssu.openssupot.domain.domain.organization.InvalidOrganizationNameException
+import com.yourssu.openssupot.domain.domain.organization.InvalidPasswordException
+import com.yourssu.openssupot.domain.domain.organization.PasswordNotEncryptedException
+import com.yourssu.openssupot.domain.support.security.password.PasswordEncodingFailureException
+import com.yourssu.openssupot.domain.support.security.token.InvalidTokenException
 import java.util.stream.Collectors
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -36,6 +43,48 @@ class GlobalExceptionHandler {
     @ExceptionHandler(ReadFailureException::class)
     fun handleReadFailureException(e: ReadFailureException): ResponseEntity<ExceptionResponse> {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ExceptionResponse(e.message))
+    }
+
+    @ExceptionHandler(DuplicateEmailException::class)
+    fun handleDuplicateEmailException(e: DuplicateEmailException): ResponseEntity<ExceptionResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ExceptionResponse(e.message))
+    }
+
+    @ExceptionHandler(InvalidEmailException::class)
+    fun handleInvalidEmailException(e: InvalidEmailException): ResponseEntity<ExceptionResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ExceptionResponse(e.message))
+    }
+
+    @ExceptionHandler(InvalidOrganizationNameException::class)
+    fun handleInvalidOrganizationNameException(e: InvalidOrganizationNameException): ResponseEntity<ExceptionResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ExceptionResponse(e.message))
+    }
+
+    @ExceptionHandler(InvalidPasswordException::class)
+    fun handleInvalidPasswordException(e: InvalidPasswordException): ResponseEntity<ExceptionResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ExceptionResponse(e.message))
+    }
+
+    @ExceptionHandler(PasswordNotEncryptedException::class)
+    fun handlePasswordNotEncryptedException(e: PasswordNotEncryptedException): ResponseEntity<ExceptionResponse> {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ExceptionResponse(e.message))
+    }
+
+    @ExceptionHandler(PasswordEncodingFailureException::class)
+    fun handlePasswordEncodingFailureException(e: PasswordEncodingFailureException): ResponseEntity<ExceptionResponse> {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ExceptionResponse(e.message))
+    }
+
+    @ExceptionHandler(InvalidTokenException::class)
+    fun handleInvalidTokenException(e: InvalidTokenException): ResponseEntity<ExceptionResponse> {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(ExceptionResponse(e.message))
     }
 

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileService.kt
@@ -13,7 +13,7 @@ class FileService {
     }
 
     @Value("\${file.upload.path}")
-    private val fileStoreDir: String? = null
+    lateinit var fileStoreDir: String
 
     fun read(storeName: String): Resource {
         val storePath = fileStoreDir + storeName
@@ -24,8 +24,9 @@ class FileService {
     }
 
     private fun validateFile(file: UrlResource, storePath: String) {
+        val fileName = storePath.substring(fileStoreDir.length)
         if (!file.exists() || !file.isReadable) {
-            throw ReadFailureException("파일이 존재하지 않거나 읽을 수 없습니다: $storePath")
+            throw ReadFailureException("파일[$fileName]이 존재하지 않거나 읽을 수 없습니다.")
         }
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/CreateOrganizationCommand.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/CreateOrganizationCommand.kt
@@ -1,0 +1,12 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.springframework.web.multipart.MultipartFile
+
+data class CreateOrganizationCommand(
+    val email: String,
+    val rawPassword: String,
+    val name: String,
+    val logoImage: MultipartFile? = null,
+    val description: String? = null,
+    val rawReservationPassword: String,
+)

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/DuplicateEmailException.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/DuplicateEmailException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+class DuplicateEmailException(
+    override val message: String
+) : RuntimeException(message)

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Email.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Email.kt
@@ -1,0 +1,49 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+class Email(
+    val emailAddress: String,
+) {
+
+    companion object{
+        private const val EMAIL_REGEX = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+    }
+
+    init {
+        validateNotBlank(emailAddress)
+        validateEmailFormat(emailAddress)
+    }
+
+    private fun validateNotBlank(emailAddress: String) {
+        if (emailAddress.isBlank()) {
+            throw InvalidEmailException("email 주소가 빈 값입니다.")
+        }
+    }
+
+    private fun validateEmailFormat(emailAddress: String) {
+        val pattern: Pattern = Pattern.compile(EMAIL_REGEX)
+        val matcher: Matcher = pattern.matcher(emailAddress)
+        if (!matcher.matches()) {
+            throw InvalidEmailException("유효하지 않은 email 형식입니다.")
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Email
+
+        return emailAddress == other.emailAddress
+    }
+
+    override fun hashCode(): Int {
+        return emailAddress.hashCode()
+    }
+
+    override fun toString(): String {
+        return "Email(emailAddress='$emailAddress')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/InvalidEmailException.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/InvalidEmailException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+class InvalidEmailException(
+    override val message: String
+) : RuntimeException(message)

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/InvalidOrganizationNameException.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/InvalidOrganizationNameException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+class InvalidOrganizationNameException (
+    override val message: String
+) : RuntimeException(message)

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/InvalidPasswordException.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/InvalidPasswordException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+class InvalidPasswordException(
+    override val message: String
+) : RuntimeException(message)

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Organization.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Organization.kt
@@ -1,0 +1,71 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import com.yourssu.openssupot.domain.support.security.password.EncryptPasswordValidator
+
+class Organization(
+    val id: Long? = null,
+    val email: Email,
+    val encryptedPassword: String,
+    val name: OrganizationName,
+    val logoImageUrl: String? = null,
+    val description: String? = null,
+    val encryptedReservationPassword: String,
+) {
+
+    init {
+        if (EncryptPasswordValidator.isNotEncrypted(encryptedPassword)) {
+            throw PasswordNotEncryptedException("비밀번호가 암호화되지 않았습니다.")
+        }
+
+        if (EncryptPasswordValidator.isNotEncrypted(encryptedReservationPassword)) {
+            throw PasswordNotEncryptedException("예약 비밀번호가 암호화되지 않았습니다.")
+        }
+    }
+
+    fun getEmailValue(): String {
+        return email.emailAddress
+    }
+
+    fun getNameValue(): String {
+        return name.name
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Organization
+
+        if (id != other.id) return false
+        if (email != other.email) return false
+        if (encryptedPassword != other.encryptedPassword) return false
+        if (name != other.name) return false
+        if (logoImageUrl != other.logoImageUrl) return false
+        if (description != other.description) return false
+        if (encryptedReservationPassword != other.encryptedReservationPassword) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id?.hashCode() ?: 0
+        result = 31 * result + email.hashCode()
+        result = 31 * result + encryptedPassword.hashCode()
+        result = 31 * result + name.hashCode()
+        result = 31 * result + (logoImageUrl?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + encryptedReservationPassword.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Organization(" +
+                "id=$id, " +
+                "email=$email, " +
+                "encryptedPassword='$encryptedPassword', " +
+                "name=$name, " +
+                "logoImageUrl=$logoImageUrl, " +
+                "description=$description, " +
+                "encryptedReservationPassword='$encryptedReservationPassword')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationName.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationName.kt
@@ -1,0 +1,45 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+class OrganizationName(
+    val name: String,
+) {
+
+    companion object {
+        private const val MIN_LENGTH = 1
+        private const val MAX_LENGTH = 20
+    }
+
+    init {
+        validateNotBlank(name)
+        validateLength(name)
+    }
+
+    private fun validateNotBlank(name: String) {
+        if (name.isBlank()) {
+            throw InvalidOrganizationNameException("단체 이름이 빈 값입니다.")
+        }
+    }
+
+    private fun validateLength(name: String) {
+        if (name.length !in MIN_LENGTH..MAX_LENGTH) {
+            throw InvalidOrganizationNameException("단체 이름은 $MIN_LENGTH~$MAX_LENGTH 글자여야 합니다.")
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as OrganizationName
+
+        return name == other.name
+    }
+
+    override fun hashCode(): Int {
+        return name.hashCode()
+    }
+
+    override fun toString(): String {
+        return "OrganizationName(name='$name')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationReader.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationReader.kt
@@ -1,0 +1,15 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class OrganizationReader(
+    private val organizationRepository: OrganizationRepository
+) {
+
+    fun existByEmail(email: String): Boolean {
+        return organizationRepository.existsByEmail(email)
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+interface OrganizationRepository {
+
+    fun save(organization: Organization): Organization
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationRepository.kt
@@ -3,4 +3,5 @@ package com.yourssu.openssupot.domain.domain.organization
 interface OrganizationRepository {
 
     fun save(organization: Organization): Organization
+    fun existsByEmail(email: String): Boolean
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
@@ -1,0 +1,37 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import com.yourssu.openssupot.domain.domain.file.FileUploader
+import com.yourssu.openssupot.domain.support.security.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class OrganizationService (
+    private val fileUploader: FileUploader,
+    private val passwordEncoder: PasswordEncoder,
+    private val organizationWriter: OrganizationWriter,
+    private val organizationReader: OrganizationReader,
+) {
+
+    fun create(
+        command: CreateOrganizationCommand,
+    ): Long {
+        if (organizationReader.existByEmail(command.email)) {
+            throw DuplicateEmailException("이미 존재하는 이메일입니다.")
+        }
+        val encryptedPassword: String = passwordEncoder.encode(command.rawPassword)
+        val encryptedReservationPassword: String = passwordEncoder.encode(command.rawReservationPassword)
+        var logoImageUrl: String? = null
+        if (command.logoImage != null) {
+            logoImageUrl = fileUploader.upload(command.logoImage)
+        }
+
+        val savedOrganization = organizationWriter.write(
+            command,
+            logoImageUrl,
+            encryptedPassword,
+            encryptedReservationPassword
+        )
+
+        return savedOrganization.id!!
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationWriter.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationWriter.kt
@@ -1,0 +1,29 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class OrganizationWriter(
+    private val organizationRepository: OrganizationRepository,
+) {
+
+    fun write(
+        command: CreateOrganizationCommand,
+        logoImageUrl: String?,
+        encryptedPassword: String,
+        encryptedReservationPassword: String,
+    ): Organization {
+        val toSave = Organization(
+            email = Email(command.email),
+            encryptedPassword = encryptedPassword,
+            name = OrganizationName(command.name),
+            logoImageUrl = logoImageUrl,
+            description = command.description,
+            encryptedReservationPassword = encryptedReservationPassword,
+        )
+
+        return organizationRepository.save(toSave)
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordNotEncryptedException.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordNotEncryptedException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+class PasswordNotEncryptedException(
+    override val message: String
+) : RuntimeException(message)

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidator.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidator.kt
@@ -1,0 +1,30 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+class PasswordValidator {
+
+    companion object {
+        private const val PASSWORD_REGEX = "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{8,}\$"
+
+        fun validate(rawPassword: String) {
+            validateNotBlank(rawPassword)
+            validatePasswordFormat(rawPassword)
+        }
+
+        private fun validateNotBlank(rawPassword: String) {
+            if (rawPassword.isBlank()) {
+                throw InvalidPasswordException("비밀번호가 빈 값입니다.")
+            }
+        }
+
+        private fun validatePasswordFormat(rawPassword: String) {
+            val pattern: Pattern = Pattern.compile(PASSWORD_REGEX)
+            val matcher: Matcher = pattern.matcher(rawPassword)
+            if (!matcher.matches()) {
+                throw InvalidPasswordException("비밀번호는 영어+숫자 8글자 이상이어야 합니다.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/support/security/password/EncryptPasswordEncoder.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/support/security/password/EncryptPasswordEncoder.kt
@@ -4,7 +4,6 @@ import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.security.SecureRandom
 import java.util.Base64
-import java.util.regex.Pattern
 import org.springframework.stereotype.Component
 
 @Component
@@ -12,7 +11,6 @@ class EncryptPasswordEncoder : PasswordEncoder {
 
     companion object {
         private const val VERSION_PREFIX = "$2a" // Spring Security의 BCryptPasswordEncoder에서 사용하는 default 값
-        private val PATTERN: Pattern = Pattern.compile("^\\$2a\\$\\d{2}\\$\\S{53}$")
         private const val STRENGTH = 10 // Spring Security의 BCryptPasswordEncoder에서 사용하는 default 값
         private val secureRandom = SecureRandom()
         private const val SALT_BYTES_LENGTH = 16
@@ -77,10 +75,7 @@ class EncryptPasswordEncoder : PasswordEncoder {
     }
 
     override fun matches(rawPassword: String, encodedPassword: String): Boolean {
-        if (encodedPassword.isBlank()) {
-            return false
-        }
-        if (!PATTERN.matcher(encodedPassword).matches()) {
+        if (EncryptPasswordValidator.isNotEncrypted(encodedPassword)) {
             return false
         }
 

--- a/src/main/kotlin/com/yourssu/openssupot/domain/support/security/password/EncryptPasswordValidator.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/support/security/password/EncryptPasswordValidator.kt
@@ -1,0 +1,16 @@
+package com.yourssu.openssupot.domain.support.security.password
+
+import java.util.regex.Pattern
+
+class EncryptPasswordValidator {
+
+    companion object {
+
+        private val PATTERN: Pattern = Pattern.compile("^\\$2a\\$\\d{2}\\$\\S{53}$")
+
+        fun isNotEncrypted(password: String): Boolean {
+            return (password.isBlank() ||
+                    !PATTERN.matcher(password).matches())
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaOrganizationRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaOrganizationRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaOrganizationRepository : JpaRepository<OrganizationEntity, Long> {
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaOrganizationRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaOrganizationRepository.kt
@@ -3,4 +3,6 @@ package com.yourssu.openssupot.storage.domain.organization
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaOrganizationRepository : JpaRepository<OrganizationEntity, Long> {
+
+    fun existsByEmail(email: String): Boolean
 }

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationEntity.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationEntity.kt
@@ -1,0 +1,85 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.Email
+import com.yourssu.openssupot.domain.domain.organization.Organization
+import com.yourssu.openssupot.domain.domain.organization.OrganizationName
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "organization")
+class OrganizationEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(unique = true, nullable = false)
+    val email: String,
+
+    @Column(nullable = false)
+    val encryptedPassword: String,
+
+    @Column(nullable = false)
+    val name: String,
+
+    @Column
+    val logoImageUrl: String? = null,
+
+    @Column
+    val description: String? = null,
+
+    @Column(nullable = false)
+    val encryptedReservationPassword: String,
+) {
+
+    companion object {
+        fun from(organization: Organization) = OrganizationEntity(
+            id = organization.id,
+            email = organization.getEmailValue(),
+            encryptedPassword = organization.encryptedPassword,
+            name = organization.getNameValue(),
+            logoImageUrl = organization.logoImageUrl,
+            description = organization.description,
+            encryptedReservationPassword = organization.encryptedReservationPassword,
+        )
+    }
+
+    fun toDomain() = Organization(
+        id = id,
+        email = Email(email),
+        encryptedPassword = encryptedPassword,
+        name = OrganizationName(name),
+        logoImageUrl = logoImageUrl,
+        description = description,
+        encryptedReservationPassword = encryptedReservationPassword,
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as OrganizationEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "OrganizationEntity(" +
+                "id=$id, " +
+                "email='$email', " +
+                "encryptedPassword='$encryptedPassword', " +
+                "name='$name', " +
+                "logoImageUrl=$logoImageUrl, " +
+                "description=$description, " +
+                "encryptedReservationPassword='$encryptedReservationPassword')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationRepositoryImpl.kt
@@ -12,4 +12,8 @@ class OrganizationRepositoryImpl(
     override fun save(organization: Organization): Organization {
         return jpaOrganizationRepository.save(OrganizationEntity.from(organization)).toDomain()
     }
+
+    override fun existsByEmail(email: String): Boolean {
+        return jpaOrganizationRepository.existsByEmail(email)
+    }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.Organization
+import com.yourssu.openssupot.domain.domain.organization.OrganizationRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class OrganizationRepositoryImpl(
+    private val jpaOrganizationRepository: JpaOrganizationRepository,
+) : OrganizationRepository {
+
+    override fun save(organization: Organization): Organization {
+        return jpaOrganizationRepository.save(OrganizationEntity.from(organization)).toDomain()
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,20 +1,20 @@
 spring:
   application:
     name: OpenSSUpot
-    datasource:
-      url: jdbc:h2:tcp://localhost/~/test
-      username: sa
-      driver-class-name: org.h2.Driver
-    jpa:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
       hibernate:
-        ddl-auto: create-drop
-      properties:
-        hibernate:
-          format_sql: true
-          dialect: org.hibernate.dialect.H2Dialect
-          show_sql: true
-          use_sql_comments: true
-      open-in-view: false
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+        show_sql: true
+        use_sql_comments: true
+    open-in-view: false
   servlet:
     multipart:
       enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,11 @@ spring:
           show_sql: true
           use_sql_comments: true
       open-in-view: false
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
 file:
   upload:
     path: /Users/kwon-yejin/Downloads/

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/EmailTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/EmailTest.kt
@@ -41,4 +41,3 @@ class EmailTest {
         assertThat(email.emailAddress).isEqualTo(validEmail)
     }
 }
-

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/EmailTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/EmailTest.kt
@@ -1,0 +1,44 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@Suppress("NonAsciiCharacters")
+class EmailTest {
+
+    @Test
+    fun `빈 이메일 주소를 생성하면 예외가 발생한다`() {
+        // given
+        val emptyEmail = "  "
+
+        // when & then
+        assertThatThrownBy { Email(emptyEmail) }
+            .isInstanceOf(InvalidEmailException::class.java)
+            .hasMessage("email 주소가 빈 값입니다.")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["invalid-email", "user@domain", "user@domain.", "user@domain@domain.com"])
+    fun `유효하지 않은 이메일 형식이면 예외가 발생한다`(invalidEmail: String) {
+        // when & then
+        assertThatThrownBy { Email(invalidEmail) }
+            .isInstanceOf(InvalidEmailException::class.java)
+            .hasMessage("유효하지 않은 email 형식입니다.")
+    }
+
+    @Test
+    fun `유효한 이메일 주소라면 객체가 정상적으로 생성된다`() {
+        // given
+        val validEmail = "encho.urssu@soongsil.ac.kr"
+
+        // when
+        val email = Email(validEmail)
+
+        // then
+        assertThat(email.emailAddress).isEqualTo(validEmail)
+    }
+}
+

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationNameTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationNameTest.kt
@@ -1,0 +1,43 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import kotlin.test.Test
+
+@Suppress("NonAsciiCharacters")
+class OrganizationNameTest {
+
+    @Test
+    fun `빈 단체 이름을 생성하면 예외가 발생한다`() {
+        // given
+        val emptyName = "  "
+
+        // when & then
+        assertThatThrownBy { OrganizationName(emptyName) }
+            .isInstanceOf(InvalidOrganizationNameException::class.java)
+            .hasMessage("단체 이름이 빈 값입니다.")
+    }
+
+    @Test
+    fun `단체 이름의 길이가 유효하지 않으면 예외가 발생한다`() {
+        // given
+        val longName = "a".repeat(21)
+
+        // when & then
+        assertThatThrownBy { OrganizationName(longName) }
+            .isInstanceOf(InvalidOrganizationNameException::class.java)
+            .hasMessage("단체 이름은 1~20 글자여야 합니다.")
+    }
+
+    @Test
+    fun `유효한 단체 이름이라면 객체가 정상적으로 생성된다`() {
+        // given
+        val validName = "Valid Name"
+
+        // when
+        val organizationName = OrganizationName(validName)
+
+        // then
+        assertThat(organizationName.name).isEqualTo(validName)
+    }
+}

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationTest.kt
@@ -1,0 +1,59 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.Test
+
+@Suppress("NonAsciiCharacters")
+class OrganizationTest {
+
+    @Test
+    fun `암호화되지 않은 비밀번호로 단체를 생성하면 예외가 발생한다`() {
+        // given
+        val plainPassword = "plainPassword"
+
+        // when & then
+        assertThatThrownBy {
+            Organization(
+                email = Email("email@email.com"),
+                encryptedPassword = plainPassword,
+                name = OrganizationName("organizationName"),
+                encryptedReservationPassword = "\$2a\$10\$SG1qTzy5vDOLYaPQ5ws/aA+K1mG2ekX+IuE8EXk/xhF0RQoNlXsXl"
+            )
+        }.isInstanceOf(PasswordNotEncryptedException::class.java)
+            .hasMessage("비밀번호가 암호화되지 않았습니다.")
+    }
+
+    @Test
+    fun `암호화되지 않은 예약 비밀번호로 단체를 생성하면 예외가 발생한다`() {
+        // given
+        val plainPassword = "plainPassword"
+
+        // when & then
+        assertThatThrownBy {
+            Organization(
+                email = Email("email@email.com"),
+                encryptedPassword = "\$2a\$10\$SG1qTzy5vDOLYaPQ5ws/aA+K1mG2ekX+IuE8EXk/xhF0RQoNlXsXl",
+                name = OrganizationName("organizationName"),
+                encryptedReservationPassword = plainPassword
+            )
+        }.isInstanceOf(PasswordNotEncryptedException::class.java)
+            .hasMessage("예약 비밀번호가 암호화되지 않았습니다.")
+    }
+
+    @Test
+    fun `암호화된 비밀번호와 예약 비밀번호로 단체를 생성하면 객체가 정상적으로 생성된다`() {
+        // given
+        val encryptPassword = "\$2a\$10\$SG1qTzy5vDOLYaPQ5ws/aA+K1mG2ekX+IuE8EXk/xhF0RQoNlXsXl"
+
+        // when & then
+        assertDoesNotThrow {
+            Organization(
+                email = Email("email@email.com"),
+                encryptedPassword = encryptPassword,
+                name = OrganizationName("organizationName"),
+                encryptedReservationPassword = encryptPassword
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidatorTest.kt
@@ -1,0 +1,38 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.Test
+
+@Suppress("NonAsciiCharacters")
+class PasswordValidatorTest {
+
+    @Test
+    fun `빈 비밀번호가 입력되면 예외가 발생한다`() {
+        // given
+        val blankPassword = "  "
+
+        // when & then
+        assertThatThrownBy { PasswordValidator.validate(blankPassword) }
+            .isInstanceOf(InvalidPasswordException::class.java)
+            .hasMessage("비밀번호가 빈 값입니다.")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["short1", "noNumberHere", "123456789"])
+    fun `유효하지 않은 비밀번호 형식이 입력되면 예외가 발생한다`(invalidPassword: String) {
+        // when & then
+        assertThatThrownBy { PasswordValidator.validate(invalidPassword) }
+            .isInstanceOf(InvalidPasswordException::class.java)
+            .hasMessage("비밀번호는 영어+숫자 8글자 이상이어야 합니다.")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["Password1", "secure123", "MyPassw0rd!@#", "Admin1234"])
+    fun `유효한 비밀번호 형식이라면 예외가 발생하지 않는다`(validPassword: String) {
+        // when & then
+        assertDoesNotThrow { PasswordValidator.validate(validPassword) }
+    }
+}

--- a/src/test/kotlin/com/yourssu/openssupot/domain/support/security/password/EncryptPasswordValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/support/security/password/EncryptPasswordValidatorTest.kt
@@ -1,0 +1,44 @@
+package com.yourssu.openssupot.domain.support.security.password
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@Suppress("NonAsciiCharacters")
+class EncryptPasswordValidatorTest {
+
+    @Test
+    fun `암호화되지 않은 비밀번호 여부를 확인할 때 비밀번호가 비어있다면 true를 반환한다`() {
+        // given
+        val emptyEncryptPassword = " "
+
+        // when
+        val actual = EncryptPasswordValidator.isNotEncrypted(emptyEncryptPassword)
+
+        // then
+        assertThat(actual).isTrue()
+    }
+
+    @Test
+    fun `암호화되지 않은 비밀번호 여부를 확인할 때, 비밀번호가 암호화 형식에 맞지 않으면 true를 반환한다`() {
+        // given
+        val invalidFormatEncryptPassword = "invalidFormat"
+
+        // when
+        val actual = EncryptPasswordValidator.isNotEncrypted(invalidFormatEncryptPassword)
+
+        // then
+        assertThat(actual).isTrue()
+    }
+
+    @Test
+    fun `암호화되지 않은 비밀번호 여부를 확인할 때, 비밀번호가 암호화 형식에 맞으면 false를 반환한다`() {
+        // given
+        val encryptPassword = "\$2a\$10\$SG1qTzy5vDOLYaPQ5ws/aA+K1mG2ekX+IuE8EXk/xhF0RQoNlXsXl"
+
+        // when
+        val actual = EncryptPasswordValidator.isNotEncrypted(encryptPassword)
+
+        // then
+        assertThat(actual).isFalse()
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
단체 생성 기능 추가
- 단체 도메인 엔티티 추가
- 비밀번호가 영어+숫자 8글자 이상인지 검증하는 기능 추가
- 비밀번호 암호화 여부를 확인하는 검증 객체추가
- 단체 생성 api 추가
- 잘못된 datasource 로컬 설정 경로 수정
- 파일 조회 실패 시 에러 메시지에 파일의 로컬 경로가 노출되는 문제 수정

## 📎 Issue 번호
- closed #3 
