### PR TITLE
단체에 해시태그 속성 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/CreateOrganizationRequest.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/CreateOrganizationRequest.kt
@@ -19,6 +19,8 @@ data class CreateOrganizationRequest(
 
     @NotBlank(message = "예약 비밀번호가 입력되지 않았습니다.")
     val reservationPassword: String,
+
+    val hashtags: List<String> = emptyList(),
 ) {
     fun toCommand(logoImage: MultipartFile?): CreateOrganizationCommand {
         return CreateOrganizationCommand(
@@ -28,6 +30,7 @@ data class CreateOrganizationRequest(
             logoImage = logoImage,
             description = description,
             rawReservationPassword = reservationPassword,
+            hashtags = hashtags
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/ReadOrganizationResponse.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/ReadOrganizationResponse.kt
@@ -8,6 +8,7 @@ data class ReadOrganizationResponse(
     val name: String,
     val logoImageUrl: String?,
     val description: String?,
+    val hashtags: List<String> = emptyList(),
 ) {
 
     companion object {
@@ -16,6 +17,7 @@ data class ReadOrganizationResponse(
             name = organizationDto.name,
             logoImageUrl = organizationDto.logoImageUrl,
             description = organizationDto.description,
+            hashtags = organizationDto.hashtags,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/CreateOrganizationCommand.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/CreateOrganizationCommand.kt
@@ -9,4 +9,5 @@ data class CreateOrganizationCommand(
     val logoImage: MultipartFile? = null,
     val description: String? = null,
     val rawReservationPassword: String,
+    val hashtags: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Hashtag.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Hashtag.kt
@@ -1,0 +1,24 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+class Hashtag(
+    val id: Long? = null,
+    val name: String,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Hashtag
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "Hashtag(id=$id, name='$name')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagReader.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagReader.kt
@@ -1,0 +1,17 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class HashtagReader(
+    private val organizationHashtagRepository: OrganizationHashtagRepository,
+    private val hashtagRepository: HashtagRepository,
+) {
+
+    fun readAllByOrganizationId(organizationId: Long) =
+        organizationHashtagRepository.findAllByOrganizationId(organizationId)
+            .map { hashtag -> hashtag.hashtagId }
+            .map { hashtagId -> hashtagRepository.findById(hashtagId)!! }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagRepository.kt
@@ -1,0 +1,7 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+interface HashtagRepository {
+
+    fun save(hashtag: Hashtag): Hashtag
+    fun findByName(name: String): Hashtag?
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagRepository.kt
@@ -3,5 +3,6 @@ package com.yourssu.openssupot.domain.domain.organization
 interface HashtagRepository {
 
     fun save(hashtag: Hashtag): Hashtag
+    fun findById(id: Long): Hashtag?
     fun findByName(name: String): Hashtag?
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagWriter.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagWriter.kt
@@ -32,5 +32,4 @@ class HashtagWriter(
 
         return savedHashtags
     }
-
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagWriter.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/HashtagWriter.kt
@@ -1,0 +1,36 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class HashtagWriter(
+    private val hashtagRepository: HashtagRepository,
+    private val organizationHashtagRepository: OrganizationHashtagRepository,
+) {
+
+    fun write(
+        organizationId: Long,
+        hashtagNames: List<String>,
+    ): List<Hashtag> {
+        val savedHashtags: MutableList<Hashtag> = mutableListOf()
+        for (hashtagName in hashtagNames) {
+            val savedHashtag: Hashtag = hashtagRepository.findByName(hashtagName)
+                ?: hashtagRepository.save(Hashtag(name = hashtagName))
+
+            organizationHashtagRepository.findByOrganizationIdAndHashtagId(organizationId, savedHashtag.id!!)
+                ?: organizationHashtagRepository.save(
+                    OrganizationHashtag(
+                        organizationId = organizationId,
+                        hashtagId = savedHashtag.id
+                    )
+                )
+
+            savedHashtags.add(savedHashtag)
+        }
+
+        return savedHashtags
+    }
+
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Organization.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Organization.kt
@@ -10,6 +10,7 @@ class Organization(
     val logoImageUrl: String? = null,
     val description: String? = null,
     val encryptedReservationPassword: String,
+    val hashtags: MutableList<Hashtag> = mutableListOf(),
 ) {
 
     init {
@@ -30,32 +31,19 @@ class Organization(
         return name.name
     }
 
+    fun getHashtagValues(): List<String> = hashtags.map { it.name }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
         other as Organization
 
-        if (id != other.id) return false
-        if (email != other.email) return false
-        if (encryptedPassword != other.encryptedPassword) return false
-        if (name != other.name) return false
-        if (logoImageUrl != other.logoImageUrl) return false
-        if (description != other.description) return false
-        if (encryptedReservationPassword != other.encryptedReservationPassword) return false
-
-        return true
+        return id == other.id
     }
 
     override fun hashCode(): Int {
-        var result = id?.hashCode() ?: 0
-        result = 31 * result + email.hashCode()
-        result = 31 * result + encryptedPassword.hashCode()
-        result = 31 * result + name.hashCode()
-        result = 31 * result + (logoImageUrl?.hashCode() ?: 0)
-        result = 31 * result + (description?.hashCode() ?: 0)
-        result = 31 * result + encryptedReservationPassword.hashCode()
-        return result
+        return id?.hashCode() ?: 0
     }
 
     override fun toString(): String {
@@ -67,5 +55,9 @@ class Organization(
                 "logoImageUrl=$logoImageUrl, " +
                 "description=$description, " +
                 "encryptedReservationPassword='$encryptedReservationPassword')"
+    }
+
+    fun addHashtags(tags: List<Hashtag>) {
+        hashtags.addAll(tags)
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationDto.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationDto.kt
@@ -7,6 +7,7 @@ data class OrganizationDto(
     val name: String,
     val logoImageUrl: String?,
     val description: String?,
+    val hashtags: List<String> = emptyList(),
 ) {
 
     companion object {
@@ -16,6 +17,7 @@ data class OrganizationDto(
             name = organization.getNameValue(),
             logoImageUrl = organization.logoImageUrl,
             description = organization.description,
+            hashtags = organization.getHashtagValues(),
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationHashtag.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationHashtag.kt
@@ -1,0 +1,8 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+class OrganizationHashtag(
+
+    val id: Long? = null,
+    val organizationId: Long,
+    val hashtagId: Long,
+)

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationHashtagRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationHashtagRepository.kt
@@ -1,0 +1,11 @@
+package com.yourssu.openssupot.domain.domain.organization
+
+interface OrganizationHashtagRepository {
+
+    fun save(organizationHashtag: OrganizationHashtag): OrganizationHashtag
+
+    fun findByOrganizationIdAndHashtagId(
+        organizationId: Long,
+        hashtagId: Long
+    ): OrganizationHashtag?
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationHashtagRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationHashtagRepository.kt
@@ -8,4 +8,6 @@ interface OrganizationHashtagRepository {
         organizationId: Long,
         hashtagId: Long
     ): OrganizationHashtag?
+
+    fun findAllByOrganizationId(organizationId: Long): List<OrganizationHashtag>
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationReader.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationReader.kt
@@ -6,7 +6,8 @@ import org.springframework.transaction.annotation.Transactional
 @Component
 @Transactional(readOnly = true)
 class OrganizationReader(
-    private val organizationRepository: OrganizationRepository
+    private val organizationRepository: OrganizationRepository,
+    private val hashtagReader: HashtagReader
 ) {
 
     fun existByEmail(email: String): Boolean {
@@ -14,16 +15,34 @@ class OrganizationReader(
     }
 
     fun getByEmail(email: String): Organization {
-        return organizationRepository.findByEmail(email)
-            ?: throw OrganizationNotFoundException("$email 로 가입한 이력이 없습니다.")
+        val savedOrganization = (organizationRepository.findByEmail(email)
+            ?: throw OrganizationNotFoundException("$email 로 가입한 이력이 없습니다."))
+
+        val hashtags: List<Hashtag> = hashtagReader.readAllByOrganizationId(savedOrganization.id!!)
+
+        savedOrganization.addHashtags(hashtags)
+
+        return savedOrganization
     }
 
     fun searchByNameKeyword(keyword: String): List<Organization> {
-        return organizationRepository.searchByNameKeyword(keyword)
+        val savedOrganizations: List<Organization> = organizationRepository.searchByNameKeyword(keyword)
+        for (savedOrganization in savedOrganizations) {
+            val hashtags: List<Hashtag> = hashtagReader.readAllByOrganizationId(savedOrganization.id!!)
+            savedOrganization.addHashtags(hashtags)
+        }
+
+        return savedOrganizations
     }
 
     fun getById(id: Long): Organization {
-        return organizationRepository.findById(id)
-            ?: throw OrganizationNotFoundException("지정한 단체를 찾을 수 없습니다.")
+        val savedOrganization: Organization = (organizationRepository.findById(id)
+            ?: throw OrganizationNotFoundException("지정한 단체를 찾을 수 없습니다."))
+
+        val hashtags: List<Hashtag> = hashtagReader.readAllByOrganizationId(savedOrganization.id!!)
+
+        savedOrganization.addHashtags(hashtags)
+
+        return savedOrganization
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationWriter.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationWriter.kt
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class OrganizationWriter(
     private val organizationRepository: OrganizationRepository,
+    private val hashtagWriter : HashtagWriter,
 ) {
 
     fun write(
@@ -23,7 +24,11 @@ class OrganizationWriter(
             description = command.description,
             encryptedReservationPassword = encryptedReservationPassword,
         )
+        val savedOrganization: Organization = organizationRepository.save(toSave)
+        val savedHashtags: List<Hashtag> = hashtagWriter.write(savedOrganization.id!!, command.hashtags)
 
-        return organizationRepository.save(toSave)
+        savedOrganization.addHashtags(savedHashtags)
+
+        return savedOrganization
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/HashtagEntity.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/HashtagEntity.kt
@@ -1,0 +1,51 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.Hashtag
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "hashtag")
+class HashtagEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false, unique = true)
+    val name: String,
+) {
+
+    companion object {
+        fun from(hashtag: Hashtag) = HashtagEntity(
+            id = hashtag.id,
+            name = hashtag.name,
+        )
+    }
+
+    fun toDomain() = Hashtag(
+        id = id,
+        name = name,
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as HashtagEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "HashtagEntity(id=$id, name='$name')"
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/HashtagRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/HashtagRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.Hashtag
+import com.yourssu.openssupot.domain.domain.organization.HashtagRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class HashtagRepositoryImpl(
+    private val jpaHashtagRepository: JpaHashtagRepository
+) : HashtagRepository {
+
+    override fun save(hashtag: Hashtag): Hashtag {
+        return jpaHashtagRepository.save(hashtag)
+    }
+
+    override fun findByName(name: String): Hashtag? {
+        return jpaHashtagRepository.findByName(name)
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/HashtagRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/HashtagRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.yourssu.openssupot.storage.domain.organization
 
 import com.yourssu.openssupot.domain.domain.organization.Hashtag
 import com.yourssu.openssupot.domain.domain.organization.HashtagRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -11,6 +12,10 @@ class HashtagRepositoryImpl(
 
     override fun save(hashtag: Hashtag): Hashtag {
         return jpaHashtagRepository.save(HashtagEntity.from(hashtag)).toDomain()
+    }
+
+    override fun findById(id: Long): Hashtag? {
+        return jpaHashtagRepository.findByIdOrNull(id)?.toDomain()
     }
 
     override fun findByName(name: String): Hashtag? {

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/HashtagRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/HashtagRepositoryImpl.kt
@@ -10,10 +10,10 @@ class HashtagRepositoryImpl(
 ) : HashtagRepository {
 
     override fun save(hashtag: Hashtag): Hashtag {
-        return jpaHashtagRepository.save(hashtag)
+        return jpaHashtagRepository.save(HashtagEntity.from(hashtag)).toDomain()
     }
 
     override fun findByName(name: String): Hashtag? {
-        return jpaHashtagRepository.findByName(name)
+        return jpaHashtagRepository.findByName(name)?.toDomain()
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaHashtagRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaHashtagRepository.kt
@@ -1,0 +1,8 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.Hashtag
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaHashtagRepository : JpaRepository<Hashtag, Long> {
+    fun findByName(name: String): Hashtag?
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaHashtagRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaHashtagRepository.kt
@@ -1,8 +1,7 @@
 package com.yourssu.openssupot.storage.domain.organization
 
-import com.yourssu.openssupot.domain.domain.organization.Hashtag
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface JpaHashtagRepository : JpaRepository<Hashtag, Long> {
-    fun findByName(name: String): Hashtag?
+interface JpaHashtagRepository : JpaRepository<HashtagEntity, Long> {
+    fun findByName(name: String): HashtagEntity?
 }

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaOrganizationHashtagRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaOrganizationHashtagRepository.kt
@@ -1,0 +1,10 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaOrganizationHashtagRepository : JpaRepository<OrganizationHashtagEntity, Long> {
+    fun findByOrganizationIdAndHashtagId(
+        organizationId: Long,
+        hashtagId: Long
+    ): OrganizationHashtagEntity?
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaOrganizationHashtagRepository.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/JpaOrganizationHashtagRepository.kt
@@ -7,4 +7,6 @@ interface JpaOrganizationHashtagRepository : JpaRepository<OrganizationHashtagEn
         organizationId: Long,
         hashtagId: Long
     ): OrganizationHashtagEntity?
+
+    fun findAllByOrganizationId(organizationId: Long): List<OrganizationHashtagEntity>
 }

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationHashtagEntity.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationHashtagEntity.kt
@@ -1,0 +1,38 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.OrganizationHashtag
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "organization_hashtag")
+class OrganizationHashtagEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val organizationId: Long,
+
+    @Column(nullable = false)
+    val hashtagId: Long,
+) {
+
+    companion object {
+        fun from(organizationHashtag: OrganizationHashtag) = OrganizationHashtagEntity(
+            organizationId = organizationHashtag.organizationId,
+            hashtagId = organizationHashtag.hashtagId,
+        )
+    }
+
+    fun toDomain() = OrganizationHashtag(
+        id = id,
+        organizationId = organizationId,
+        hashtagId = hashtagId,
+    )
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationHashtagRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationHashtagRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.yourssu.openssupot.storage.domain.organization
+
+import com.yourssu.openssupot.domain.domain.organization.OrganizationHashtag
+import com.yourssu.openssupot.domain.domain.organization.OrganizationHashtagRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class OrganizationHashtagRepositoryImpl(
+    private val jpaOrganizationHashtagRepository: JpaOrganizationHashtagRepository
+) : OrganizationHashtagRepository {
+
+    override fun save(organizationHashtag: OrganizationHashtag): OrganizationHashtag {
+        return jpaOrganizationHashtagRepository.save(OrganizationHashtagEntity.from(organizationHashtag)).toDomain()
+    }
+
+    override fun findByOrganizationIdAndHashtagId(
+        organizationId: Long,
+        hashtagId: Long
+    ): OrganizationHashtag? {
+        return jpaOrganizationHashtagRepository.findByOrganizationIdAndHashtagId(organizationId, hashtagId)?.toDomain()
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationHashtagRepositoryImpl.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationHashtagRepositoryImpl.kt
@@ -19,4 +19,8 @@ class OrganizationHashtagRepositoryImpl(
     ): OrganizationHashtag? {
         return jpaOrganizationHashtagRepository.findByOrganizationIdAndHashtagId(organizationId, hashtagId)?.toDomain()
     }
+
+    override fun findAllByOrganizationId(organizationId: Long): List<OrganizationHashtag> {
+        return jpaOrganizationHashtagRepository.findAllByOrganizationId(organizationId).map { it.toDomain() }
+    }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,6 +5,10 @@ spring:
     url: jdbc:h2:mem:testdb
     username: sa
     driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
## 📄 작업 내용 요약
- 단체 회원 가입 request에 해시태그 속성 추가
- 단체 도메인 및 엔티티에 해시태그 속성 추가
- 단체가 오픈한 공간 조회 response에 단체의 해시태그 속성 추가

## 📎 Issue 번호
- closed #28 
