### PR TITLE
단체 로고 및 공간 이미지가 없는 경우 핸들링

### DIFF
--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/ReadOrganizationResponse.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/ReadOrganizationResponse.kt
@@ -6,7 +6,7 @@ data class ReadOrganizationResponse(
 
     val id: Long,
     val name: String,
-    val logoImageUrl: String?,
+    val logoImageUrl: String,
     val description: String?,
     val hashtags: List<String> = emptyList(),
 ) {

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileProcessor.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileProcessor.kt
@@ -2,7 +2,7 @@ package com.yourssu.openssupot.domain.domain.file
 
 import org.springframework.web.multipart.MultipartFile
 
-interface FileUploader {
+interface FileProcessor {
 
     fun upload(multipartFile: MultipartFile) : String
     fun uploadAll(multipartFiles: List<MultipartFile>) : List<String>

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileProcessor.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileProcessor.kt
@@ -7,4 +7,5 @@ interface FileProcessor {
     fun upload(multipartFile: MultipartFile) : String
     fun uploadAll(multipartFiles: List<MultipartFile>) : List<String>
     fun getFileStorePath(storeName: String) : String
+    fun getDefaultOrganizationImageUrl(): String
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileProcessor.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileProcessor.kt
@@ -6,4 +6,5 @@ interface FileProcessor {
 
     fun upload(multipartFile: MultipartFile) : String
     fun uploadAll(multipartFiles: List<MultipartFile>) : List<String>
+    fun getFileStorePath(storeName: String) : String
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/FileService.kt
@@ -1,32 +1,29 @@
 package com.yourssu.openssupot.domain.domain.file
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.Resource
 import org.springframework.core.io.UrlResource
 import org.springframework.stereotype.Service
 
 @Service
-class FileService {
+class FileService(
+    private val fileProcessor: FileProcessor,
+) {
 
     companion object {
         private const val FILE_PROTOCOL_PREFIX = "file:"
     }
 
-    @Value("\${file.upload.path}")
-    lateinit var fileStoreDir: String
-
     fun read(storeName: String): Resource {
-        val storePath = fileStoreDir + storeName
+        val storePath = fileProcessor.getFileStorePath(storeName)
         val file = UrlResource(FILE_PROTOCOL_PREFIX + storePath)
-        validateFile(file, storePath)
+        validateFile(file, storeName)
 
         return file
     }
 
-    private fun validateFile(file: UrlResource, storePath: String) {
-        val fileName = storePath.substring(fileStoreDir.length)
+    private fun validateFile(file: UrlResource, storeName: String) {
         if (!file.exists() || !file.isReadable) {
-            throw ReadFailureException("파일[$fileName]이 존재하지 않거나 읽을 수 없습니다.")
+            throw ReadFailureException("파일[$storeName]이 존재하지 않거나 읽을 수 없습니다.")
         }
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessor.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessor.kt
@@ -8,13 +8,14 @@ import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 
 @Component
-class LocalFileProcessor : FileProcessor {
+class LocalFileProcessor(
 
     @Value("\${file.upload.path}")
-    lateinit var uploadPath: String
+    val uploadPath: String,
 
     @Value("\${file.web.path}")
-    lateinit var webApiPath: String
+    val webApiPath: String,
+) : FileProcessor {
 
     companion object {
         private val EXTENSION = listOf("jpg", "jpeg", "png")
@@ -61,4 +62,6 @@ class LocalFileProcessor : FileProcessor {
 
         return extension
     }
+
+    override fun getFileStorePath(storeName: String): String = uploadPath + storeName
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessor.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessor.kt
@@ -15,6 +15,10 @@ class LocalFileProcessor(
 
     @Value("\${file.web.path}")
     val webApiPath: String,
+
+    @Value("\${file.default-imag-name.organization}")
+    val defaultOrganizationImageName: String,
+
 ) : FileProcessor {
 
     companion object {
@@ -64,4 +68,6 @@ class LocalFileProcessor(
     }
 
     override fun getFileStorePath(storeName: String): String = uploadPath + storeName
+
+    override fun getDefaultOrganizationImageUrl(): String = webApiPath + defaultOrganizationImageName
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessor.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessor.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 
 @Component
-class LocalFileUploader : FileUploader {
+class LocalFileProcessor : FileProcessor {
 
     @Value("\${file.upload.path}")
     lateinit var uploadPath: String

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Organization.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Organization.kt
@@ -7,7 +7,7 @@ class Organization(
     val email: Email,
     val encryptedPassword: String,
     val name: OrganizationName,
-    val logoImageUrl: String? = null,
+    val logoImageUrl: String,
     val description: String? = null,
     val encryptedReservationPassword: String,
     val hashtags: MutableList<Hashtag> = mutableListOf(),

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationDto.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationDto.kt
@@ -5,7 +5,7 @@ data class OrganizationDto(
     val id: Long,
     val email: String,
     val name: String,
-    val logoImageUrl: String?,
+    val logoImageUrl: String,
     val description: String?,
     val hashtags: List<String> = emptyList(),
 ) {

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
@@ -1,12 +1,12 @@
 package com.yourssu.openssupot.domain.domain.organization
 
-import com.yourssu.openssupot.domain.domain.file.FileUploader
+import com.yourssu.openssupot.domain.domain.file.FileProcessor
 import com.yourssu.openssupot.domain.support.security.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
 class OrganizationService (
-    private val fileUploader: FileUploader,
+    private val fileProcessor: FileProcessor,
     private val passwordEncoder: PasswordEncoder,
     private val organizationWriter: OrganizationWriter,
     private val organizationReader: OrganizationReader,
@@ -20,7 +20,7 @@ class OrganizationService (
         }
         val encryptedPassword: String = passwordEncoder.encode(command.rawPassword)
         val encryptedReservationPassword: String = passwordEncoder.encode(command.rawReservationPassword)
-        val logoImageUrl: String? = command.logoImage?.let { fileUploader.upload(it) }
+        val logoImageUrl: String? = command.logoImage?.let { fileProcessor.upload(it) }
 
         val savedOrganization = organizationWriter.write(
             command,

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
@@ -21,10 +21,9 @@ class OrganizationService (
         val encryptedPassword: String = passwordEncoder.encode(command.rawPassword)
         val encryptedReservationPassword: String = passwordEncoder.encode(command.rawReservationPassword)
 
-        var logoImageUrl: String = fileProcessor.getDefaultOrganizationImageUrl()
-        if (command.logoImage != null) {
-            logoImageUrl = fileProcessor.upload(command.logoImage)
-        }
+        val logoImageUrl: String = command.logoImage?.let {
+            fileProcessor.upload(it)
+        } ?: fileProcessor.getDefaultOrganizationImageUrl()
 
         val savedOrganization = organizationWriter.write(
             command,

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
@@ -20,7 +20,11 @@ class OrganizationService (
         }
         val encryptedPassword: String = passwordEncoder.encode(command.rawPassword)
         val encryptedReservationPassword: String = passwordEncoder.encode(command.rawReservationPassword)
-        val logoImageUrl: String? = command.logoImage?.let { fileProcessor.upload(it) }
+
+        var logoImageUrl: String = fileProcessor.getDefaultOrganizationImageUrl()
+        if (command.logoImage != null) {
+            logoImageUrl = fileProcessor.upload(command.logoImage)
+        }
 
         val savedOrganization = organizationWriter.write(
             command,

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationWriter.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationWriter.kt
@@ -12,7 +12,7 @@ class OrganizationWriter(
 
     fun write(
         command: CreateOrganizationCommand,
-        logoImageUrl: String?,
+        logoImageUrl: String,
         encryptedPassword: String,
         encryptedReservationPassword: String,
     ): Organization {

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/ReadSpaceResponse.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/ReadSpaceResponse.kt
@@ -7,21 +7,26 @@ data class ReadSpaceResponse(
     val id: Long,
     val name: String,
     val location: String,
-    val spaceImageUrl: String?,
+    val spaceImageUrl: String,
     val openingTime: LocalTime,
     val closingTime: LocalTime,
     val capacity: Int,
 ) {
 
     companion object {
-        fun from(spaceDto: SpaceDto) = ReadSpaceResponse(
-            id = spaceDto.id!!,
-            name = spaceDto.name,
-            location = spaceDto.location,
-            spaceImageUrl = spaceDto.spaceImageUrl,
-            openingTime = spaceDto.openingTime,
-            closingTime = spaceDto.closingTime,
-            capacity = spaceDto.capacity,
-        )
+        fun from(spaceDto: SpaceDto) : ReadSpaceResponse {
+            val spaceImageUrl: String = spaceDto.spaceImageUrl
+                ?: spaceDto.organization.logoImageUrl
+
+            return ReadSpaceResponse(
+                id = spaceDto.id!!,
+                name = spaceDto.name,
+                location = spaceDto.location,
+                spaceImageUrl = spaceImageUrl,
+                openingTime = spaceDto.openingTime,
+                closingTime = spaceDto.closingTime,
+                capacity = spaceDto.capacity,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/SpaceService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/SpaceService.kt
@@ -1,13 +1,13 @@
 package com.yourssu.openssupot.domain.domain.space
 
-import com.yourssu.openssupot.domain.domain.file.FileUploader
+import com.yourssu.openssupot.domain.domain.file.FileProcessor
 import com.yourssu.openssupot.domain.domain.organization.Organization
 import com.yourssu.openssupot.domain.domain.organization.OrganizationReader
 import org.springframework.stereotype.Service
 
 @Service
 class SpaceService(
-    private val fileUploader: FileUploader,
+    private val fileProcessor: FileProcessor,
     private val organizationReader: OrganizationReader,
     private val spaceWriter: SpaceWriter,
     private val spaceReader: SpaceReader,
@@ -17,7 +17,7 @@ class SpaceService(
         command: CreateSpaceCommand
     ): Long {
         val organization: Organization = organizationReader.getById(command.organizationId)
-        val spaceImageUrl: String? = command.spaceImage?.let { fileUploader.upload(it) }
+        val spaceImageUrl: String? = command.spaceImage?.let { fileProcessor.upload(it) }
         val savedSpace = spaceWriter.write(command, organization, spaceImageUrl)
 
         return savedSpace.id!!

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationEntity.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/organization/OrganizationEntity.kt
@@ -27,8 +27,8 @@ class OrganizationEntity(
     @Column(nullable = false)
     val name: String,
 
-    @Column
-    val logoImageUrl: String? = null,
+    @Column(nullable = false)
+    val logoImageUrl: String,
 
     @Column
     val description: String? = null,

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,11 +24,15 @@ spring:
       enabled: true
       max-file-size: 10MB
       max-request-size: 10MB
+
 file:
   upload:
     path: /Users/kwon-yejin/Downloads/
   web:
     path: http://localhost:8080/files/
+  default-imag-name:
+    organization: default_organization.png
+
 token:
   jwt:
     access-key: ThisIsLocalAccessKeyThisIsLocalAccessKey

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessorTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessorTest.kt
@@ -15,10 +15,10 @@ import org.springframework.mock.web.MockMultipartFile
 
 @Suppress("NonAsciiCharacters")
 @SpringBootTest
-class LocalFileUploaderTest {
+class LocalFileProcessorTest {
 
     @Autowired
-    private val localFileUploader = LocalFileUploader()
+    private val localFileUploader = LocalFileProcessor()
 
     private val mockFile = mock(MockMultipartFile::class.java)
 


### PR DESCRIPTION
## 📄 작업 내용 요약
- 단체 생성 시 로고 이미지가 없는 경우 기본 이미지 url 할당
- 공간 목록 조회 response에서 공간 이미지 url이 없으면 기본 이미지 url을 반환하는 로직 추가
- 로컬 파일 처리 객체에서 설정값 읽어올 때 lateinit 제거
- 파일 관련 설정값은 FileProcessor의 구현체만 갖도록 리팩토링

## 📎 Issue 번호
- closed #30 
