### PR TITLE
공간 정보 수정 기능 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/UpdateOrganizationRequest.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/organization/UpdateOrganizationRequest.kt
@@ -12,9 +12,10 @@ data class UpdateOrganizationRequest(
     val reservationPassword: String? = null,
     val hashtags: List<String> = emptyList(),
 ) {
-    fun toCommand(targetOrganizationId: Long, logoImage: MultipartFile?): UpdateOrganizationCommand {
-        println("request hashtags = ${hashtags}")
-        return UpdateOrganizationCommand(
+    fun toCommand(
+        targetOrganizationId: Long,
+        logoImage: MultipartFile?
+    ): UpdateOrganizationCommand = UpdateOrganizationCommand(
             targetOrganizationId = targetOrganizationId,
             name = name,
             logoImage = logoImage,
@@ -22,5 +23,4 @@ data class UpdateOrganizationRequest(
             rawReservationPassword = reservationPassword,
             hashtags = hashtags
         )
-    }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/space/SpaceController.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/space/SpaceController.kt
@@ -59,5 +59,4 @@ class SpaceController(
 
         return ResponseEntity.ok().build()
     }
-    )
 }

--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/space/SpaceController.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/space/SpaceController.kt
@@ -9,6 +9,8 @@ import jakarta.validation.Valid
 import java.net.URI
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
@@ -42,4 +44,20 @@ class SpaceController(
 
         return ResponseEntity.ok(response)
     }
+
+    @PatchMapping("/spaces/{spaceId}")
+    fun update(
+        @AuthenticationOrganization authInfo: AuthenticationOrganizationInfo,
+        @PathVariable spaceId: Long,
+        @RequestPart(required = false) image: MultipartFile?,
+        @RequestPart @Valid request: UpdateSpaceRequest,
+    ): ResponseEntity<Unit> {
+        spaceService.update(
+            authInfo.organizationId,
+            request.toCommand(spaceId, image)
+        )
+
+        return ResponseEntity.ok().build()
+    }
+    )
 }

--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/space/UpdateSpaceRequest.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/space/UpdateSpaceRequest.kt
@@ -1,0 +1,40 @@
+package com.yourssu.openssupot.application.domain.space
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.yourssu.openssupot.domain.domain.space.UpdateSpaceOrganizationCommand
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalTime
+import org.springframework.web.multipart.MultipartFile
+
+data class UpdateSpaceRequest(
+
+    @NotBlank(message = "공간 이름이 입력되지 않았습니다.")
+    val name: String,
+
+    @NotBlank(message = "장소가 입력되지 않았습니다.")
+    val location: String,
+
+    @NotBlank(message = "오픈 시간이 입력되지 않았습니다.")
+    @JsonFormat(pattern = "HH:mm")
+    val openingTime: LocalTime,
+
+    @NotBlank(message = "종료 시간이 입력되지 않았습니다.")
+    @JsonFormat(pattern = "HH:mm")
+    val closingTime: LocalTime,
+
+    @NotBlank(message = "수용 인원이 입력되지 않았습니다.")
+    val capacity: Int,
+) {
+
+        fun toCommand(
+            targetSpaceId: Long, spaceImage: MultipartFile?
+        ): UpdateSpaceOrganizationCommand = UpdateSpaceOrganizationCommand(
+            targetSpaceId = targetSpaceId,
+            name = name,
+            location = location,
+            spaceImage = spaceImage,
+            openingTime = openingTime,
+            closingTime = closingTime,
+            capacity = capacity,
+        )
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/Reservation.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/Reservation.kt
@@ -9,11 +9,6 @@ class Reservation(
     val bookerName: String,
     val reservationTime: ReservationTime,
 ) {
-    init {
-        if (!space.canReserve(reservationTime)) {
-            throw InvalidReservationException("공간 사용 가능 시간이 아닙니다.")
-        }
-    }
 
     fun getStartDateTime(): LocalDateTime {
         return reservationTime.startDateTime

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/ReservationService.kt
@@ -22,10 +22,15 @@ class ReservationService(
             throw PasswordNotMatchException("예약 비밀번호가 일치하지 않습니다.")
         }
 
+        val reservationTime = ReservationTime(command.startDateTime, command.endDateTime)
+        if (!space.canReserve(reservationTime)) {
+            throw InvalidReservationException("공간 사용 가능 시간이 아닙니다.")
+        }
+
         val reservation = Reservation(
             space = space,
             bookerName = command.bookerName,
-            reservationTime = ReservationTime(command.startDateTime, command.endDateTime),
+            reservationTime = reservationTime,
         )
 
         if (reservationReader.isTimeConflict(reservation)) {

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/Space.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/Space.kt
@@ -18,6 +18,24 @@ class Space(
         return operatingTime.isAvailableTime(reservationTime)
     }
 
+    fun updateAndReturnNew(
+        name: String? = this.name,
+        location: String? = this.location,
+        spaceImageUrl: String? = this.spaceImageUrl,
+        operatingTime: SpaceOperatingTime? = this.operatingTime,
+        capacity: Capacity? = this.capacity,
+    ): Space {
+        return Space(
+            id = this.id,
+            organization = organization,
+            name = name ?: this.name,
+            location = location ?: this.location,
+            spaceImageUrl = spaceImageUrl ?: this.spaceImageUrl,
+            operatingTime = operatingTime ?: this.operatingTime,
+            capacity = capacity ?: this.capacity
+        )
+    }
+
     fun getEncryptedReservationPassword(): String {
         return organization.encryptedReservationPassword
     }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/SpaceService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/SpaceService.kt
@@ -3,6 +3,7 @@ package com.yourssu.openssupot.domain.domain.space
 import com.yourssu.openssupot.domain.domain.file.FileProcessor
 import com.yourssu.openssupot.domain.domain.organization.Organization
 import com.yourssu.openssupot.domain.domain.organization.OrganizationReader
+import com.yourssu.openssupot.domain.domain.organization.UnauthorizedOrganizationException
 import org.springframework.stereotype.Service
 
 @Service
@@ -28,5 +29,23 @@ class SpaceService(
         val spaces: List<Space> = spaceReader.readAllByOrganization(organization)
 
         return ReadSpacesResult.from(organization, spaces)
+    }
+
+    fun update(requestOrganizationId: Long, command: UpdateSpaceOrganizationCommand) {
+        val organization: Organization = organizationReader.getById(requestOrganizationId)
+        val space: Space = spaceReader.getById(command.targetSpaceId)
+        if (organization != space.organization) {
+            throw UnauthorizedOrganizationException("본인의 단체의 공간만 수정할 수 있습니다.")
+        }
+
+        val updatedSpace: Space = space.updateAndReturnNew(
+            name = command.name,
+            location = command.location,
+            spaceImageUrl = command.spaceImage?.let { fileProcessor.upload(it) },
+            operatingTime = SpaceOperatingTime(command.openingTime, command.closingTime),
+            capacity = Capacity(command.capacity),
+        )
+
+        spaceWriter.update(updatedSpace)
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/SpaceWriter.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/SpaceWriter.kt
@@ -26,4 +26,6 @@ class SpaceWriter(
 
         return spaceRepository.save(toSave)
     }
+
+    fun update(updatedSpace: Space) = spaceRepository.save(updatedSpace)
 }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/UpdateSpaceOrganizationCommand.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/space/UpdateSpaceOrganizationCommand.kt
@@ -1,0 +1,16 @@
+package com.yourssu.openssupot.domain.domain.space
+
+import java.time.LocalTime
+import org.springframework.web.multipart.MultipartFile
+
+data class UpdateSpaceOrganizationCommand(
+
+    val targetSpaceId: Long,
+    val name: String,
+    val location: String,
+    val spaceImage: MultipartFile? = null,
+    val openingTime: LocalTime,
+    val closingTime: LocalTime,
+    val capacity: Int,
+) {
+}

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessorTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/file/LocalFileProcessorTest.kt
@@ -18,7 +18,11 @@ import org.springframework.mock.web.MockMultipartFile
 class LocalFileProcessorTest {
 
     @Autowired
-    private val localFileUploader = LocalFileProcessor()
+    private val localFileUploader = LocalFileProcessor(
+        "src/test/resources",
+        "http://localhost:8080",
+        "default.png"
+    )
 
     private val mockFile = mock(MockMultipartFile::class.java)
 

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationTest.kt
@@ -18,6 +18,7 @@ class OrganizationTest {
                 email = Email("email@email.com"),
                 encryptedPassword = plainPassword,
                 name = OrganizationName("organizationName"),
+                logoImageUrl = "logoImageUrl",
                 encryptedReservationPassword = "\$2a\$10\$SG1qTzy5vDOLYaPQ5ws/aA+K1mG2ekX+IuE8EXk/xhF0RQoNlXsXl"
             )
         }.isInstanceOf(PasswordNotEncryptedException::class.java)
@@ -35,6 +36,7 @@ class OrganizationTest {
                 email = Email("email@email.com"),
                 encryptedPassword = "\$2a\$10\$SG1qTzy5vDOLYaPQ5ws/aA+K1mG2ekX+IuE8EXk/xhF0RQoNlXsXl",
                 name = OrganizationName("organizationName"),
+                logoImageUrl = "logoImageUrl",
                 encryptedReservationPassword = plainPassword
             )
         }.isInstanceOf(PasswordNotEncryptedException::class.java)
@@ -52,6 +54,7 @@ class OrganizationTest {
                 email = Email("email@email.com"),
                 encryptedPassword = encryptPassword,
                 name = OrganizationName("organizationName"),
+                logoImageUrl = "logoImageUrl",
                 encryptedReservationPassword = encryptPassword
             )
         }


### PR DESCRIPTION
## 📄 작업 내용 요약
- 공간 정보 수정 api 추가
- 공간 정보 수정으로 공간의 이용 가능 시간을 수정한 경우, 이전에 생성했던 예약을 조회하는 과정에서 예약 시간이 공간 운영 시간에 해당하지 않아 예외가 발생하는 버그 해결 (예약 도메인 생성 시 검증하지 않고 예약 service에서 예약을 저장하기 전에 검증하도록 수정

## 📎 Issue 번호
- closed #27 
