### PR TITLE
공간 예약 시 개인 비밀번호 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/openssupot/application/domain/reservation/CreateReservationRequest.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/domain/reservation/CreateReservationRequest.kt
@@ -20,6 +20,9 @@ data class CreateReservationRequest(
 
     @NotBlank(message = "예약 비밀번호가 입력되지 않았습니다.")
     val password: String,
+
+    @NotBlank(message = "예약 취소에 사용할 비밀번호가 입력되지 않았습니다.")
+    val personalPassword: String,
 ) {
 
     fun toCommand(
@@ -31,6 +34,7 @@ data class CreateReservationRequest(
             startDateTime = startDateTime,
             endDateTime = endDateTime,
             password = password,
+            rawPersonalPassword = personalPassword,
         )
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/application/support/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/application/support/exception/GlobalExceptionHandler.kt
@@ -11,9 +11,9 @@ import com.yourssu.openssupot.domain.domain.file.UnsupportedFileExtensionExcepti
 import com.yourssu.openssupot.domain.domain.organization.DuplicateEmailException
 import com.yourssu.openssupot.domain.domain.organization.InvalidEmailException
 import com.yourssu.openssupot.domain.domain.organization.InvalidOrganizationNameException
-import com.yourssu.openssupot.domain.domain.organization.InvalidPasswordException
+import com.yourssu.openssupot.domain.domain.password.InvalidPasswordException
 import com.yourssu.openssupot.domain.domain.organization.OrganizationNotFoundException
-import com.yourssu.openssupot.domain.domain.organization.PasswordNotEncryptedException
+import com.yourssu.openssupot.domain.domain.password.PasswordNotEncryptedException
 import com.yourssu.openssupot.domain.domain.organization.UnauthorizedOrganizationException
 import com.yourssu.openssupot.domain.domain.reservation.InvalidReservationException
 import com.yourssu.openssupot.domain.domain.reservation.InvalidReservationTimeException

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Organization.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/Organization.kt
@@ -1,5 +1,6 @@
 package com.yourssu.openssupot.domain.domain.organization
 
+import com.yourssu.openssupot.domain.domain.password.PasswordNotEncryptedException
 import com.yourssu.openssupot.domain.support.security.password.EncryptPasswordValidator
 
 class Organization(

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
@@ -15,6 +15,7 @@ class OrganizationService (
     fun create(
         command: CreateOrganizationCommand,
     ): Long {
+        PasswordValidator.validateOrganizationPassword(command.rawPassword)
         if (organizationReader.existByEmail(command.email)) {
             throw DuplicateEmailException("이미 존재하는 이메일입니다.")
         }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
@@ -1,6 +1,7 @@
 package com.yourssu.openssupot.domain.domain.organization
 
 import com.yourssu.openssupot.domain.domain.file.FileProcessor
+import com.yourssu.openssupot.domain.domain.password.PasswordValidator
 import com.yourssu.openssupot.domain.support.security.password.PasswordEncoder
 import org.springframework.stereotype.Service
 

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationService.kt
@@ -1,6 +1,7 @@
 package com.yourssu.openssupot.domain.domain.organization
 
 import com.yourssu.openssupot.domain.domain.file.FileProcessor
+import com.yourssu.openssupot.domain.domain.password.PasswordFormat
 import com.yourssu.openssupot.domain.domain.password.PasswordValidator
 import com.yourssu.openssupot.domain.support.security.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -16,7 +17,7 @@ class OrganizationService (
     fun create(
         command: CreateOrganizationCommand,
     ): Long {
-        PasswordValidator.validateOrganizationPassword(command.rawPassword)
+        PasswordValidator.validate(PasswordFormat.ORGANIZATION_PASSWORD, command.rawPassword)
         if (organizationReader.existByEmail(command.email)) {
             throw DuplicateEmailException("이미 존재하는 이메일입니다.")
         }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidator.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidator.kt
@@ -9,7 +9,7 @@ class PasswordValidator {
         private const val ORGANIZATION_PASSWORD_REGEX = "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{8,}\$"
         private const val PERSONAL_RESERVATION_PASSWORD_REGEX = "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{4,}\$"
 
-        fun validate(rawPassword: String) {
+        fun validateOrganizationPassword(rawPassword: String) {
             validateNotBlank(rawPassword)
             validatePasswordFormat(rawPassword)
         }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidator.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidator.kt
@@ -6,7 +6,8 @@ import java.util.regex.Pattern
 class PasswordValidator {
 
     companion object {
-        private const val PASSWORD_REGEX = "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{8,}\$"
+        private const val ORGANIZATION_PASSWORD_REGEX = "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{8,}\$"
+        private const val PERSONAL_RESERVATION_PASSWORD_REGEX = "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{4,}\$"
 
         fun validate(rawPassword: String) {
             validateNotBlank(rawPassword)
@@ -20,10 +21,19 @@ class PasswordValidator {
         }
 
         private fun validatePasswordFormat(rawPassword: String) {
-            val pattern: Pattern = Pattern.compile(PASSWORD_REGEX)
+            val pattern: Pattern = Pattern.compile(ORGANIZATION_PASSWORD_REGEX)
             val matcher: Matcher = pattern.matcher(rawPassword)
             if (!matcher.matches()) {
                 throw InvalidPasswordException("비밀번호는 영어+숫자 8글자 이상이어야 합니다.")
+            }
+        }
+
+        fun validatePersonalPassword(rawPersonalPassword: String) {
+            validateNotBlank(rawPersonalPassword)
+            val pattern: Pattern = Pattern.compile(PERSONAL_RESERVATION_PASSWORD_REGEX)
+            val matcher: Matcher = pattern.matcher(rawPersonalPassword)
+            if (!matcher.matches()) {
+                throw InvalidPasswordException("비밀번호는 영어+숫자 4글자 이상이어야 합니다.")
             }
         }
     }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/InvalidPasswordException.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/InvalidPasswordException.kt
@@ -1,4 +1,4 @@
-package com.yourssu.openssupot.domain.domain.organization
+package com.yourssu.openssupot.domain.domain.password
 
 class InvalidPasswordException(
     override val message: String

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/PasswordFormat.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/PasswordFormat.kt
@@ -1,0 +1,14 @@
+package com.yourssu.openssupot.domain.domain.password
+
+enum class PasswordFormat(val regex: String, val errorMessage: String) {
+
+    ORGANIZATION_PASSWORD(
+        "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{8,}\$",
+        "비밀번호는 영어+숫자 8글자 이상이어야 합니다."
+    ),
+
+    PERSONAL_RESERVATION_PASSWORD(
+        "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{4,}\$",
+        "비밀번호는 영어+숫자 4글자 이상이어야 합니다."
+    )
+}

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/PasswordNotEncryptedException.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/PasswordNotEncryptedException.kt
@@ -1,4 +1,4 @@
-package com.yourssu.openssupot.domain.domain.organization
+package com.yourssu.openssupot.domain.domain.password
 
 class PasswordNotEncryptedException(
     override val message: String

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/PasswordValidator.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/PasswordValidator.kt
@@ -6,12 +6,10 @@ import java.util.regex.Pattern
 class PasswordValidator {
 
     companion object {
-        private const val ORGANIZATION_PASSWORD_REGEX = "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{8,}\$"
-        private const val PERSONAL_RESERVATION_PASSWORD_REGEX = "^(?=(.*[a-zA-Z]))(?=(.*\\d))[a-zA-Z\\d!@#\$%^&*()_+=-]{4,}\$"
 
-        fun validateOrganizationPassword(rawPassword: String) {
+        fun validate(passwordFormat: PasswordFormat, rawPassword: String) {
             validateNotBlank(rawPassword)
-            validatePasswordFormat(rawPassword)
+            validatePasswordFormat(passwordFormat, rawPassword)
         }
 
         private fun validateNotBlank(rawPassword: String) {
@@ -20,20 +18,11 @@ class PasswordValidator {
             }
         }
 
-        private fun validatePasswordFormat(rawPassword: String) {
-            val pattern: Pattern = Pattern.compile(ORGANIZATION_PASSWORD_REGEX)
+        private fun validatePasswordFormat(format: PasswordFormat, rawPassword: String) {
+            val pattern: Pattern = Pattern.compile(format.regex)
             val matcher: Matcher = pattern.matcher(rawPassword)
             if (!matcher.matches()) {
-                throw InvalidPasswordException("비밀번호는 영어+숫자 8글자 이상이어야 합니다.")
-            }
-        }
-
-        fun validatePersonalPassword(rawPersonalPassword: String) {
-            validateNotBlank(rawPersonalPassword)
-            val pattern: Pattern = Pattern.compile(PERSONAL_RESERVATION_PASSWORD_REGEX)
-            val matcher: Matcher = pattern.matcher(rawPersonalPassword)
-            if (!matcher.matches()) {
-                throw InvalidPasswordException("비밀번호는 영어+숫자 4글자 이상이어야 합니다.")
+                throw InvalidPasswordException(format.errorMessage)
             }
         }
     }

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/PasswordValidator.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/password/PasswordValidator.kt
@@ -1,4 +1,4 @@
-package com.yourssu.openssupot.domain.domain.organization
+package com.yourssu.openssupot.domain.domain.password
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/CreateReservationCommand.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/CreateReservationCommand.kt
@@ -9,4 +9,5 @@ data class CreateReservationCommand(
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime,
     val password: String,
+    val rawPersonalPassword: String,
 )

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/Reservation.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/Reservation.kt
@@ -1,6 +1,8 @@
 package com.yourssu.openssupot.domain.domain.reservation
 
+import com.yourssu.openssupot.domain.domain.organization.PasswordNotEncryptedException
 import com.yourssu.openssupot.domain.domain.space.Space
+import com.yourssu.openssupot.domain.support.security.password.EncryptPasswordValidator
 import java.time.LocalDateTime
 
 class Reservation(
@@ -8,7 +10,14 @@ class Reservation(
     val space: Space,
     val bookerName: String,
     val reservationTime: ReservationTime,
+    val encryptedPersonalPassword: String,
 ) {
+
+    init {
+        if (EncryptPasswordValidator.isNotEncrypted(encryptedPersonalPassword)) {
+            throw PasswordNotEncryptedException("예약 취소에 사용할 비밀번호가 암호화되지 않았습니다.")
+        }
+    }
 
     fun getStartDateTime(): LocalDateTime {
         return reservationTime.startDateTime

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/Reservation.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/Reservation.kt
@@ -1,6 +1,6 @@
 package com.yourssu.openssupot.domain.domain.reservation
 
-import com.yourssu.openssupot.domain.domain.organization.PasswordNotEncryptedException
+import com.yourssu.openssupot.domain.domain.password.PasswordNotEncryptedException
 import com.yourssu.openssupot.domain.domain.space.Space
 import com.yourssu.openssupot.domain.support.security.password.EncryptPasswordValidator
 import java.time.LocalDateTime

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/ReservationService.kt
@@ -1,7 +1,7 @@
 package com.yourssu.openssupot.domain.domain.reservation
 
 import com.yourssu.openssupot.domain.domain.authentication.PasswordNotMatchException
-import com.yourssu.openssupot.domain.domain.organization.PasswordValidator
+import com.yourssu.openssupot.domain.domain.password.PasswordValidator
 import com.yourssu.openssupot.domain.domain.space.Space
 import com.yourssu.openssupot.domain.domain.space.SpaceReader
 import com.yourssu.openssupot.domain.support.security.password.PasswordEncoder

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/ReservationService.kt
@@ -1,6 +1,7 @@
 package com.yourssu.openssupot.domain.domain.reservation
 
 import com.yourssu.openssupot.domain.domain.authentication.PasswordNotMatchException
+import com.yourssu.openssupot.domain.domain.organization.PasswordValidator
 import com.yourssu.openssupot.domain.domain.space.Space
 import com.yourssu.openssupot.domain.domain.space.SpaceReader
 import com.yourssu.openssupot.domain.support.security.password.PasswordEncoder
@@ -27,10 +28,14 @@ class ReservationService(
             throw InvalidReservationException("공간 사용 가능 시간이 아닙니다.")
         }
 
+        PasswordValidator.validatePersonalPassword(command.rawPersonalPassword)
+
+        val encryptedPersonalPassword: String = passwordEncoder.encode(command.rawPersonalPassword)
         val reservation = Reservation(
             space = space,
             bookerName = command.bookerName,
             reservationTime = reservationTime,
+            encryptedPersonalPassword = encryptedPersonalPassword,
         )
 
         if (reservationReader.isTimeConflict(reservation)) {

--- a/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/domain/domain/reservation/ReservationService.kt
@@ -1,6 +1,7 @@
 package com.yourssu.openssupot.domain.domain.reservation
 
 import com.yourssu.openssupot.domain.domain.authentication.PasswordNotMatchException
+import com.yourssu.openssupot.domain.domain.password.PasswordFormat
 import com.yourssu.openssupot.domain.domain.password.PasswordValidator
 import com.yourssu.openssupot.domain.domain.space.Space
 import com.yourssu.openssupot.domain.domain.space.SpaceReader
@@ -28,7 +29,7 @@ class ReservationService(
             throw InvalidReservationException("공간 사용 가능 시간이 아닙니다.")
         }
 
-        PasswordValidator.validatePersonalPassword(command.rawPersonalPassword)
+        PasswordValidator.validate(PasswordFormat.PERSONAL_RESERVATION_PASSWORD, command.rawPersonalPassword)
 
         val encryptedPersonalPassword: String = passwordEncoder.encode(command.rawPersonalPassword)
         val reservation = Reservation(

--- a/src/main/kotlin/com/yourssu/openssupot/storage/domain/reservation/ReservationEntity.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/storage/domain/reservation/ReservationEntity.kt
@@ -35,6 +35,9 @@ class ReservationEntity(
 
     @Column(nullable = false)
     val endDateTime: LocalDateTime,
+
+    @Column(nullable = false)
+    val encryptedPersonalPassword: String,
 ) {
 
     companion object {
@@ -44,6 +47,7 @@ class ReservationEntity(
             bookerName = reservation.bookerName,
             startDateTime = reservation.getStartDateTime(),
             endDateTime = reservation.getEndDateTime(),
+            encryptedPersonalPassword = reservation.encryptedPersonalPassword,
         )
     }
 
@@ -52,5 +56,6 @@ class ReservationEntity(
         space = space.toDomain(),
         bookerName = bookerName,
         reservationTime = ReservationTime(startDateTime, endDateTime),
+        encryptedPersonalPassword = encryptedPersonalPassword,
     )
 }

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/OrganizationTest.kt
@@ -1,5 +1,6 @@
 package com.yourssu.openssupot.domain.domain.organization
 
+import com.yourssu.openssupot.domain.domain.password.PasswordNotEncryptedException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.Test

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidatorTest.kt
@@ -1,6 +1,7 @@
 package com.yourssu.openssupot.domain.domain.organization
 
 import com.yourssu.openssupot.domain.domain.password.InvalidPasswordException
+import com.yourssu.openssupot.domain.domain.password.PasswordFormat
 import com.yourssu.openssupot.domain.domain.password.PasswordValidator
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -17,24 +18,24 @@ class PasswordValidatorTest {
         val blankPassword = "  "
 
         // when & then
-        assertThatThrownBy { PasswordValidator.validateOrganizationPassword(blankPassword) }
+        assertThatThrownBy { PasswordValidator.validate(PasswordFormat.ORGANIZATION_PASSWORD, blankPassword) }
             .isInstanceOf(InvalidPasswordException::class.java)
             .hasMessage("비밀번호가 빈 값입니다.")
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["short1", "noNumberHere", "123456789"])
-    fun `유효하지 않은 비밀번호 형식이 입력되면 예외가 발생한다`(invalidPassword: String) {
+    fun `유효하지 않은 단체 비밀번호 형식이 입력되면 예외가 발생한다`(invalidPassword: String) {
         // when & then
-        assertThatThrownBy { PasswordValidator.validateOrganizationPassword(invalidPassword) }
+        assertThatThrownBy { PasswordValidator.validate(PasswordFormat.ORGANIZATION_PASSWORD, invalidPassword) }
             .isInstanceOf(InvalidPasswordException::class.java)
-            .hasMessage("비밀번호는 영어+숫자 8글자 이상이어야 합니다.")
+            .hasMessage(PasswordFormat.ORGANIZATION_PASSWORD.errorMessage)
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["Password1", "secure123", "MyPassw0rd!@#", "Admin1234"])
-    fun `유효한 비밀번호 형식이라면 예외가 발생하지 않는다`(validPassword: String) {
+    fun `유효한 단체 비밀번호 형식이라면 예외가 발생하지 않는다`(validPassword: String) {
         // when & then
-        assertDoesNotThrow { PasswordValidator.validateOrganizationPassword(validPassword) }
+        assertDoesNotThrow { PasswordValidator.validate(PasswordFormat.ORGANIZATION_PASSWORD, validPassword) }
     }
 }

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidatorTest.kt
@@ -1,5 +1,7 @@
 package com.yourssu.openssupot.domain.domain.organization
 
+import com.yourssu.openssupot.domain.domain.password.InvalidPasswordException
+import com.yourssu.openssupot.domain.domain.password.PasswordValidator
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest

--- a/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidatorTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/domain/domain/organization/PasswordValidatorTest.kt
@@ -15,7 +15,7 @@ class PasswordValidatorTest {
         val blankPassword = "  "
 
         // when & then
-        assertThatThrownBy { PasswordValidator.validate(blankPassword) }
+        assertThatThrownBy { PasswordValidator.validateOrganizationPassword(blankPassword) }
             .isInstanceOf(InvalidPasswordException::class.java)
             .hasMessage("비밀번호가 빈 값입니다.")
     }
@@ -24,7 +24,7 @@ class PasswordValidatorTest {
     @ValueSource(strings = ["short1", "noNumberHere", "123456789"])
     fun `유효하지 않은 비밀번호 형식이 입력되면 예외가 발생한다`(invalidPassword: String) {
         // when & then
-        assertThatThrownBy { PasswordValidator.validate(invalidPassword) }
+        assertThatThrownBy { PasswordValidator.validateOrganizationPassword(invalidPassword) }
             .isInstanceOf(InvalidPasswordException::class.java)
             .hasMessage("비밀번호는 영어+숫자 8글자 이상이어야 합니다.")
     }
@@ -33,6 +33,6 @@ class PasswordValidatorTest {
     @ValueSource(strings = ["Password1", "secure123", "MyPassw0rd!@#", "Admin1234"])
     fun `유효한 비밀번호 형식이라면 예외가 발생하지 않는다`(validPassword: String) {
         // when & then
-        assertDoesNotThrow { PasswordValidator.validate(validPassword) }
+        assertDoesNotThrow { PasswordValidator.validateOrganizationPassword(validPassword) }
     }
 }

--- a/src/test/kotlin/com/yourssu/openssupot/storage/domain/reservation/ReservationRepositoryImplTest.kt
+++ b/src/test/kotlin/com/yourssu/openssupot/storage/domain/reservation/ReservationRepositoryImplTest.kt
@@ -205,6 +205,7 @@ class ReservationRepositoryImplTest {
                 space = space,
                 bookerName = "booker",
                 reservationTime = ReservationTime(startDateTime, endDateTime),
+                encryptedPersonalPassword = "\$2a\$10\$SG1qTzy5vDOLYaPQ5ws/aA+K1mG2ekX+IuE8EXk/xhF0RQoNlXsXl",
             )
         )
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
공간 예약 시 개인 비밀번호 추가
- 예약자가 사용하는 예약에 대한 비밀번호 처리 (이후 예약 취소에 사용될 예정)
- 단체 생성 시 단체 비밀번호에 대한 검증 메서드를 호출하지 않은 버그 해결
- 비밀번호 검증 객체 패키지 위치 변경 및 리팩토링

## 📎 Issue 번호
- closed #45 
