### PR TITLE
사용 가능한 도서관 세미나실 조회 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.3")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -26,6 +32,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation ("io.jsonwebtoken:jjwt-api:0.12.6")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
     runtimeOnly ("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly ("io.jsonwebtoken:jjwt-jackson:0.12.6")

--- a/src/main/kotlin/com/yourssu/openssupot/campus/application/domain/CampusSpaceController.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/application/domain/CampusSpaceController.kt
@@ -1,0 +1,25 @@
+package com.yourssu.openssupot.campus.application.domain
+
+import com.yourssu.openssupot.campus.domain.domain.CampusSpaceService
+import java.time.LocalDateTime
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CampusSpaceController(
+    private val campusSpaceService: CampusSpaceService,
+) {
+
+    @GetMapping("/meetingrooms")
+    fun readAll(
+        @RequestParam startDateTime: LocalDateTime,
+        @RequestParam endDateTime: LocalDateTime,
+    ): List<ReadMeetingRoomResponse> {
+
+        return campusSpaceService.readAllByTimeRange(startDateTime, endDateTime)
+            .map {
+                ReadMeetingRoomResponse.from(it)
+            }
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/campus/application/domain/ReadMeetingRoomResponse.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/application/domain/ReadMeetingRoomResponse.kt
@@ -1,0 +1,25 @@
+package com.yourssu.openssupot.campus.application.domain
+
+import com.yourssu.openssupot.campus.domain.domain.ReadMeetingRoomDto
+
+data class ReadMeetingRoomResponse(
+    val name: String,
+    val spaceImageUrl: String,
+    val location: String,
+    val operatingTime: String,
+    val capacity: String,
+    val reservationUrl: String,
+) {
+    companion object {
+        fun from(dto: ReadMeetingRoomDto): ReadMeetingRoomResponse {
+            return ReadMeetingRoomResponse(
+                name = dto.name,
+                spaceImageUrl = dto.spaceImageUrl,
+                location = dto.location,
+                operatingTime = dto.operatingTime,
+                capacity = dto.capacity,
+                reservationUrl = dto.reservationUrl,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/CampusSpaceService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/CampusSpaceService.kt
@@ -1,0 +1,37 @@
+package com.yourssu.openssupot.campus.domain.domain
+
+import com.yourssu.openssupot.campus.domain.domain.oasis.OasisReader
+import com.yourssu.openssupot.campus.domain.domain.oasis.SeminarRoom
+import com.yourssu.openssupot.spacehub.domain.domain.file.FileProcessor
+import java.time.LocalDate
+import java.time.LocalDateTime
+import org.springframework.stereotype.Service
+
+@Service
+class CampusSpaceService(
+    private val oasisReader: OasisReader,
+    private val fileProcessor: FileProcessor,  // TODO: 기본 이미지 처리 리팩토링 필요
+) {
+
+    fun readAllByTimeRange(startDateTime: LocalDateTime, endDateTime: LocalDateTime): List<ReadMeetingRoomDto> {
+        val availableSeminarRooms: List<SeminarRoom> = oasisReader.getAllByDate(startDateTime.toLocalDate())
+            .filter {
+                it.isAvailable(
+                    startDateTime.toLocalTime(),
+                    endDateTime.toLocalTime()
+                )
+            }
+
+        return availableSeminarRooms.map {
+            ReadMeetingRoomDto.from(
+                it,
+                fileProcessor.getDefaultOrganizationImageUrl(),
+                getReservationUrl(it.id, startDateTime.toLocalDate())
+            )
+        }
+    }
+
+    private fun getReservationUrl(seminarRoomId: Int, hopeDay: LocalDate): String {
+        return "https://oasis.ssu.ac.kr/library-services/smuf/rooms/$seminarRoomId/$hopeDay"
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/ReadMeetingRoomDto.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/ReadMeetingRoomDto.kt
@@ -1,0 +1,27 @@
+package com.yourssu.openssupot.campus.domain.domain
+
+import com.yourssu.openssupot.campus.domain.domain.oasis.SeminarRoom
+
+data class ReadMeetingRoomDto(
+    val id: Int,
+    val name: String,
+    val spaceImageUrl: String,
+    val location: String,
+    val operatingTime: String,
+    val capacity: String,
+    val reservationUrl: String,
+) {
+    companion object {
+        fun from(seminarRoom: SeminarRoom, spaceImageUrl: String, reservationUrl: String): ReadMeetingRoomDto {
+            return ReadMeetingRoomDto(
+                id = seminarRoom.id,
+                name = seminarRoom.name,
+                spaceImageUrl = spaceImageUrl,
+                location = seminarRoom.roomType.location,
+                operatingTime = seminarRoom.roomType.operatingTime,
+                capacity = seminarRoom.capacity,
+                reservationUrl = reservationUrl,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/OasisClient.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/OasisClient.kt
@@ -1,0 +1,94 @@
+package com.yourssu.openssupot.campus.domain.domain.oasis
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "oasisClient", url = "https://oasis.ssu.ac.kr")
+interface OasisClient {
+
+    @PostMapping("/pyxis-api/api/login")
+    fun login(request: LoginRequest): LoginResponse
+
+    @GetMapping("/pyxis-api/1/api/rooms")
+    fun getSeminarRooms(
+        @RequestHeader("pyxis-auth-token") accessToken: String,
+        @RequestParam("roomTypeId") roomTypeId: Long = 1L,
+        @RequestParam("smufMethodCode") smufMethodCode: String = "PC",
+        @RequestParam("hopeDate") hopeDate: String,
+    ): SeminarRoomsResponse
+
+    @GetMapping("/pyxis-api/1/api/rooms")
+    fun getOpenSeminarRooms(
+        @RequestHeader("pyxis-auth-token") accessToken: String,
+        @RequestParam("roomTypeId") roomTypeId: Long = 5L,
+        @RequestParam("smufMethodCode") smufMethodCode: String = "PC",
+        @RequestParam("hopeDate") hopeDate: String,
+    ): SeminarRoomsResponse
+}
+
+data class LoginRequest(
+    val isFamilyLogin: Boolean = false,
+    val isMobile: Boolean = false,
+    val loginId: String,
+    val password: String,
+)
+
+data class LoginResponse(
+    val success: Boolean,
+    val data: DateItem?,
+)
+
+data class DateItem(
+    val accessToken: String,
+)
+
+data class SeminarRoomsResponse(
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: DataResponseItem
+)
+
+data class DataResponseItem(
+    val totalCount: Int,
+    val list: List<RoomResponseItem>
+)
+
+data class RoomResponseItem(
+    val id: Int,
+    val name: String,
+    val roomType: RoomTypeResponseItem,
+    val floor: FloorResponseItem,
+    val minQuota: Int,
+    val maxQuota: Int,
+    val quota: String,
+    val hopeDate: String,
+    val isChargeable: Boolean,
+    val timeLine: List<TimeSlotResponseItem>
+)
+
+data class RoomTypeResponseItem(
+    val id: Int,
+    val name: String,
+    val sortOrder: Int
+)
+
+data class FloorResponseItem(
+    val value: Int,
+    val label: String
+)
+
+data class TimeSlotResponseItem(
+    val hour: Int,
+    val minutes: List<MinuteSlotResponseItem>
+)
+
+data class MinuteSlotResponseItem(
+    @JsonProperty("class")
+    val status: String,
+    val selectable: Boolean? = null
+)

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/OasisReader.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/OasisReader.kt
@@ -1,0 +1,67 @@
+package com.yourssu.openssupot.campus.domain.domain.oasis
+
+import java.time.LocalDate
+import org.springframework.stereotype.Component
+
+@Component
+class OasisReader(
+    private val oasisTokenProvider: OasisTokenProvider,
+    private val oasisClient: OasisClient,
+) {
+
+    fun getAllByDate(date: LocalDate): List<SeminarRoom> {
+        val seminarRooms = mutableListOf<SeminarRoom>()
+
+        val seminarRoomsResponse: SeminarRoomsResponse = getSeminarRoomsResponse(date)
+        seminarRooms.addAll(seminarRoomsResponse.data.list.map {
+            SeminarRoom.from(it, RoomType.SEMINAR_ROOM)
+        })
+
+        val openSeminarRoomsResponse: SeminarRoomsResponse = getOpenSeminarRoomsResponse(date)
+        seminarRooms.addAll(openSeminarRoomsResponse.data.list.map {
+            SeminarRoom.from(it, RoomType.OPEN_SEMINAR_ROOM)
+        })
+
+        return seminarRooms
+    }
+
+    private fun getSeminarRoomsResponse(
+        date: LocalDate,
+        isRecursive: Boolean = false,
+    ): SeminarRoomsResponse {
+        val seminarRoomsResponse: SeminarRoomsResponse = oasisClient.getSeminarRooms(
+            accessToken = oasisTokenProvider.getAccessToken(),
+            hopeDate = date.toString(),
+        )
+        if (!seminarRoomsResponse.success) {
+            check(!isRecursive) { "Failed to get seminar rooms" }
+
+            oasisTokenProvider.invalidateAccessToken()
+            oasisTokenProvider.fetchNewAccessToken()
+
+            return getSeminarRoomsResponse(date, true)
+        }
+
+        return seminarRoomsResponse
+    }
+
+    private fun getOpenSeminarRoomsResponse(
+        date: LocalDate,
+        isRecursive: Boolean = false,
+    ): SeminarRoomsResponse {
+        val openSeminarRoomsResponse: SeminarRoomsResponse = oasisClient.getOpenSeminarRooms(
+            accessToken = oasisTokenProvider.getAccessToken(),
+            hopeDate = date.toString(),
+        )
+        if (!openSeminarRoomsResponse.success) {
+            check(!isRecursive) { "Failed to get open seminar rooms" }
+
+            oasisTokenProvider.invalidateAccessToken()
+            oasisTokenProvider.fetchNewAccessToken()
+
+            return getOpenSeminarRoomsResponse(date, true)
+        }
+
+        return openSeminarRoomsResponse
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/OasisTokenProvider.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/OasisTokenProvider.kt
@@ -1,0 +1,45 @@
+package com.yourssu.openssupot.campus.domain.domain.oasis
+
+import java.util.concurrent.locks.ReentrantLock
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import kotlin.concurrent.withLock
+
+@Component
+class OasisTokenProvider(
+
+    private val oasisClient: OasisClient,
+
+    @Value("\${oasis.loginId}")
+    private val loginId: String,
+
+    @Value("\${oasis.password}")
+    private val password: String,
+) {
+
+    private var accessToken: String? = null
+    private var lock = ReentrantLock()
+
+    fun getAccessToken(): String {
+        return accessToken ?: fetchNewAccessToken()
+    }
+
+    fun fetchNewAccessToken(): String {
+        lock.withLock {
+            if (accessToken == null) {
+                val loginRequest = LoginRequest(loginId = loginId, password = password)
+                val loginResponse: LoginResponse = oasisClient.login(loginRequest)
+
+                accessToken = loginResponse.data?.accessToken
+                    ?: throw IllegalStateException("Failed to get access token from Oasis")
+            }
+        }
+        return accessToken ?: throw IllegalStateException("Failed to get access token from Oasis")
+    }
+
+    fun invalidateAccessToken() {
+        lock.withLock {
+            accessToken = null
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/SeminarRoom.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/SeminarRoom.kt
@@ -1,0 +1,58 @@
+package com.yourssu.openssupot.campus.domain.domain.oasis
+
+class SeminarRoom(
+    val id: Int,
+    val name: String,
+    val roomType: RoomType,
+    val capacity: String,
+    val isChargeable: Boolean,
+    val timeLine: List<TimeSlot>
+) {
+
+    companion object {
+        fun from(roomResponseItem: RoomResponseItem, roomType: RoomType): SeminarRoom {
+            return SeminarRoom(
+                id = roomResponseItem.id,
+                name = roomResponseItem.name,
+                roomType = roomType,
+                capacity = roomResponseItem.quota,
+                isChargeable = roomResponseItem.isChargeable,
+                timeLine = roomResponseItem.timeLine.map { TimeSlot.from(it) }
+            )
+        }
+    }
+}
+
+enum class RoomType(val id: Int, val location: String, val operatingTime: String) {
+    SEMINAR_ROOM(1, "중앙도서관 1층", "10:00 ~ 21:00 (학기-평일)\n09:00 ~ 15:00 (학기-토요일)\n10:00~19:30(방학-평일)"),
+    OPEN_SEMINAR_ROOM(5, "중앙도서관 숭실스퀘어(1F)", "06:00 ~ 23:30 (학기)\n06:00 ~ 23:30 (방학)")
+}
+
+class TimeSlot(
+    val hour: Int,
+    val minutes: List<MinuteSlot>
+) {
+    companion object {
+        fun from(timeSlotResponseItem: TimeSlotResponseItem): TimeSlot {
+            return TimeSlot(
+                hour = timeSlotResponseItem.hour,
+                minutes = timeSlotResponseItem.minutes.map { MinuteSlot.from(it) }
+            )
+        }
+    }
+}
+
+class MinuteSlot(
+
+    val status: String,
+    val selectable: Boolean? = null
+) {
+    companion object {
+        fun from(minuteSlotResponseItem: MinuteSlotResponseItem): MinuteSlot {
+            return MinuteSlot(
+                status = minuteSlotResponseItem.status,
+                selectable = minuteSlotResponseItem.selectable,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/SeminarRoom.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/oasis/SeminarRoom.kt
@@ -1,5 +1,7 @@
 package com.yourssu.openssupot.campus.domain.domain.oasis
 
+import java.time.LocalTime
+
 class SeminarRoom(
     val id: Int,
     val name: String,
@@ -8,6 +10,36 @@ class SeminarRoom(
     val isChargeable: Boolean,
     val timeLine: List<TimeSlot>
 ) {
+
+    fun isAvailable(startTime: LocalTime, endTime: LocalTime): Boolean {
+        if (!isChargeable) {
+            return false
+        }
+
+        for (timeSlot in timeLine) {
+            if (timeSlot.hour >= 24) {
+                continue
+            }
+
+            val slotHourTime = LocalTime.of(timeSlot.hour, 0)
+            for ((index, minuteSlot) in timeSlot.minutes.withIndex()) {
+                val slotStartTime = slotHourTime.plusMinutes(index * 10L)
+                val slotEndTime = slotStartTime.plusMinutes(10L)
+
+                if (slotEndTime <= startTime || endTime <= slotStartTime) {
+                    continue
+                }
+
+                if (minuteSlot.status != "" || minuteSlot.selectable == false) {
+                    return false
+                }
+            }
+        }
+
+        val lastTimeSlot = timeLine[timeLine.size - 1]
+
+        return endTime.hour <= lastTimeSlot.hour
+    }
 
     companion object {
         fun from(roomResponseItem: RoomResponseItem, roomType: RoomType): SeminarRoom {

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/support/configuration/OpenFeignConfiguration.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/support/configuration/OpenFeignConfiguration.kt
@@ -1,0 +1,9 @@
+package com.yourssu.openssupot.campus.domain.support.configuration
+
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients(basePackages = ["com.yourssu.openssupot.campus"])
+class OpenFeignConfiguration {
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -39,3 +39,7 @@ token:
     refresh-key: ThisIsLocalRefreshKeyThisIsLocalRefreshKey
     access-expired-hours: 1 # 1시간
     refresh-expired-hours: 336  # 14일
+
+oasis:
+  loginId: 12345678
+  password: password1234


### PR DESCRIPTION
## 📄 작업 내용 요약
사용 가능한 도서관 세미나실 조회 기능 추가
- 외부 api 호출을 통해 도서관 세미나실에 로그인해서 인증에 사용할 정보 획득
- 매번 access token을 받지 않고, 만료되기 전까지 앱 내에서 재사용할 수 있도록 구현
- 획득한 access token으로 외부 api 호출을 통해 선택한 날짜에 대한 모든 세미나실의 예약 정보 조회
- 조회한 예약 정보를 통해 선택한 시간에 사용 가능한 회의실만 필터링해서 반환

## 📎 Issue 번호
- closed #51 
