### PR TITLE
사용 가능한 회의실 조회에 창업지원단 공간 포함

### DIFF
--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/CampusSpaceService.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/CampusSpaceService.kt
@@ -2,6 +2,8 @@ package com.yourssu.openssupot.campus.domain.domain
 
 import com.yourssu.openssupot.campus.domain.domain.oasis.OasisReader
 import com.yourssu.openssupot.campus.domain.domain.oasis.SeminarRoom
+import com.yourssu.openssupot.campus.domain.domain.startupportal.StartupPortalReader
+import com.yourssu.openssupot.campus.domain.domain.startupportal.StartupSpace
 import com.yourssu.openssupot.spacehub.domain.domain.file.FileProcessor
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -10,10 +12,21 @@ import org.springframework.stereotype.Service
 @Service
 class CampusSpaceService(
     private val oasisReader: OasisReader,
+    private val startupPortalReader: StartupPortalReader,
     private val fileProcessor: FileProcessor,  // TODO: 기본 이미지 처리 리팩토링 필요
 ) {
 
     fun readAllByTimeRange(startDateTime: LocalDateTime, endDateTime: LocalDateTime): List<ReadMeetingRoomDto> {
+        val oasisMeetingRoomDtos: List<ReadMeetingRoomDto> = readFromOasis(startDateTime, endDateTime)
+        val startupPortalMeetingRoomDtos: List<ReadMeetingRoomDto> = readFromStartupPortal(startDateTime, endDateTime)
+
+        return oasisMeetingRoomDtos + startupPortalMeetingRoomDtos
+    }
+
+    private fun readFromOasis(
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime
+    ): List<ReadMeetingRoomDto> {
         val availableSeminarRooms: List<SeminarRoom> = oasisReader.getAllByDate(startDateTime.toLocalDate())
             .filter {
                 it.isAvailable(
@@ -26,12 +39,33 @@ class CampusSpaceService(
             ReadMeetingRoomDto.from(
                 it,
                 fileProcessor.getDefaultOrganizationImageUrl(),
-                getReservationUrl(it.id, startDateTime.toLocalDate())
+                getOasisReservationUrl(it.id, startDateTime.toLocalDate())
             )
         }
     }
 
-    private fun getReservationUrl(seminarRoomId: Int, hopeDay: LocalDate): String {
+    private fun getOasisReservationUrl(seminarRoomId: Int, hopeDay: LocalDate): String {
         return "https://oasis.ssu.ac.kr/library-services/smuf/rooms/$seminarRoomId/$hopeDay"
+    }
+
+    private fun readFromStartupPortal(
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime
+    ): List<ReadMeetingRoomDto> {
+        val availableStartupSpaces: List<StartupSpace> = startupPortalReader.getAllByDate(startDateTime.toLocalDate())
+            .filter {
+                it.isAvailable(
+                    startDateTime.toLocalTime(),
+                    endDateTime.toLocalTime()
+                )
+            }
+
+        return availableStartupSpaces.map {
+            ReadMeetingRoomDto.from(it, getStartupSpaceReservationUrl())
+        }
+    }
+
+    private fun getStartupSpaceReservationUrl(): String {
+        return "https://startup.ssu.ac.kr/foundation/reservation/space"
     }
 }

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/ReadMeetingRoomDto.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/ReadMeetingRoomDto.kt
@@ -1,6 +1,7 @@
 package com.yourssu.openssupot.campus.domain.domain
 
 import com.yourssu.openssupot.campus.domain.domain.oasis.SeminarRoom
+import com.yourssu.openssupot.campus.domain.domain.startupportal.StartupSpace
 
 data class ReadMeetingRoomDto(
     val id: Int,
@@ -20,6 +21,18 @@ data class ReadMeetingRoomDto(
                 location = seminarRoom.roomType.location,
                 operatingTime = seminarRoom.roomType.operatingTime,
                 capacity = seminarRoom.capacity,
+                reservationUrl = reservationUrl,
+            )
+        }
+
+        fun from(startupSpace: StartupSpace, reservationUrl: String): ReadMeetingRoomDto {
+            return ReadMeetingRoomDto(
+                id = startupSpace.id,
+                name = startupSpace.spaceType.spaceName,
+                spaceImageUrl = startupSpace.spaceType.spaceImageUrl,
+                location = startupSpace.spaceType.location,
+                operatingTime = startupSpace.spaceType.operatingTime,
+                capacity = startupSpace.spaceType.capacity,
                 reservationUrl = reservationUrl,
             )
         }

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/startupportal/StartupPortalClient.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/startupportal/StartupPortalClient.kt
@@ -1,0 +1,30 @@
+package com.yourssu.openssupot.campus.domain.domain.startupportal
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "startupPortalClient", url = "https://startup.ssu.ac.kr")
+interface StartupPortalClient {
+
+    @GetMapping("/api/rental/time/list/{spaceId}?bookingDate=2024-11-25")
+    fun getRentalTimes(
+        @PathVariable("spaceId") spaceId: Long,
+        @RequestParam("bookingDate") bookingDate: String,
+    ): RentalTimesResponse
+}
+
+data class RentalTimesResponse(
+    val message: String?,
+    val data: List<RentalTimeItem>,
+    val code: Int
+)
+
+data class RentalTimeItem(
+    val rownum: Int,
+    val rentalTimeId: Int,
+    val rentalItemId: Int,
+    val rentalTime: String,
+    val possibleYn: String
+)

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/startupportal/StartupPortalReader.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/startupportal/StartupPortalReader.kt
@@ -1,0 +1,24 @@
+package com.yourssu.openssupot.campus.domain.domain.startupportal
+
+import java.time.LocalDate
+import org.springframework.stereotype.Component
+
+@Component
+class StartupPortalReader(
+    private val startupPortalClient: StartupPortalClient,
+) {
+
+    fun getAllByDate(date: LocalDate): List<StartupSpace> {
+        val startupSpaces = mutableListOf<StartupSpace>()
+
+        for (spaceType in SpaceType.entries) {
+            val rentalTimesResponse = startupPortalClient.getRentalTimes(
+                spaceId = spaceType.id.toLong(),
+                bookingDate = date.toString(),
+            )
+            startupSpaces.add(StartupSpace.from(rentalTimesResponse))
+        }
+
+        return startupSpaces
+    }
+}

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/startupportal/StartupSpace.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/startupportal/StartupSpace.kt
@@ -7,6 +7,25 @@ class StartupSpace(
     val spaceType: SpaceType,
     val rentals: List<RentalStatus>,
 ) {
+
+    fun isAvailable(startTime: LocalTime, endTime: LocalTime): Boolean {
+        for (rental in rentals) {
+            val slotStartTime = rental.rentalTime
+            val slotEndTime = rental.rentalTime.plusHours(1L)
+            if (slotEndTime <= startTime || endTime <= slotStartTime) {
+                continue
+            }
+
+            if (!rental.possible) {
+                return false
+            }
+        }
+
+        val lastTime = rentals[rentals.size - 1].rentalTime.plusHours(1L)
+
+        return endTime <= lastTime
+    }
+
     companion object {
         fun from(
             rentalTimesResponse: RentalTimesResponse

--- a/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/startupportal/StartupSpace.kt
+++ b/src/main/kotlin/com/yourssu/openssupot/campus/domain/domain/startupportal/StartupSpace.kt
@@ -1,0 +1,143 @@
+package com.yourssu.openssupot.campus.domain.domain.startupportal
+
+import java.time.LocalTime
+
+class StartupSpace(
+    val id: Int,
+    val spaceType: SpaceType,
+    val rentals: List<RentalStatus>,
+) {
+    companion object {
+        fun from(
+            rentalTimesResponse: RentalTimesResponse
+        ): StartupSpace {
+            val spaceId = rentalTimesResponse.data[0].rentalItemId
+            return StartupSpace(
+                id = spaceId,
+                spaceType = SpaceType.of(spaceId),
+                rentals = rentalTimesResponse.data.map { RentalStatus.from(it) }
+            )
+        }
+    }
+}
+
+class RentalStatus(
+    val rentalTime: LocalTime,
+    val possible: Boolean,
+) {
+
+    companion object {
+        fun from(rentalTimeItem: RentalTimeItem): RentalStatus {
+            return RentalStatus(
+                rentalTime = LocalTime.parse(rentalTimeItem.rentalTime),
+                possible = rentalTimeItem.possibleYn == "Y"
+            )
+        }
+    }
+}
+
+enum class SpaceType(
+    val id: Int,
+    val spaceName: String,
+    val spaceImageUrl: String,
+    val location: String,
+    val operatingTime: String,
+    val capacity: String,
+) {
+
+    TECH_STATION_B108(
+        22,
+        "테크스테이션 B108",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2F30ae0cd7-7276-4825-8ec3-1b62c0a136c4.png&w=1920&q=75",
+        "테크스테이션 지하 108호 회의실",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    TECH_STATION_B107(
+        23,
+        "테크스테이션 B107",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2F3861ede4-a9dc-4053-8ff9-fa1c3f4efef1.png&w=1920&q=75",
+        "테크스테이션 지하 107호 회의실",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    STATION_365_203(
+        30,
+        "365스테이션 203호 회의실",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2F9ad7a33f-83ca-495a-91af-5d435ef7e5b5.png&w=1080&q=75",
+        "365스테이션 203호 회의실",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    CHALLENGE_STATION(
+        29,
+        "챌린지스테이션 2층 회의실",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2F9db6baa6-a457-422c-bd65-2114c19e62a7.png&w=1080&q=75",
+        "챌린지스테이션 2층 회의실",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    VENTURE_STUDIO_PASSION(
+        25,
+        "프로젝트룸 Passion",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2F14e18aa5-583d-406f-889c-00741b57ae06.png&w=1200&q=75",
+        "벤처중소기업센터 2층 벤처스튜디오",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    VENTURE_STUDIO_UNIQUE(
+        26,
+        "프로젝트룸 Unique",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2Fbc082ab9-5c06-484d-8f7e-e064b4046ee2.png&w=1200&q=75",
+        "벤처중소기업센터 2층 벤처스튜디오",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    VENTURE_STUDIO_MAKE(
+        27,
+        "프로젝트룸 Make",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2Fe49168a5-6598-4690-9f2a-859ad85364b2.png&w=1200&q=75",
+        "벤처중소기업센터 2층 벤처스튜디오",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    VENTURE_STUDIO_PIONEER(
+        28,
+        "프로젝트룸 Pioneer",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2F43101f18-4db5-4897-bb17-3a6c6dc244ce.png&w=1200&q=75",
+        "벤처중소기업센터 2층 벤처스튜디오",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    CHANGSHIN_HALL_309(
+        24,
+        "창신관 309호",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2F4b186a60-c770-4ffb-ac2e-c6aa2d7ff831.png&w=1200&q=75",
+        "창신관 309호",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    CHANGUI_HALL_B102(
+        32,
+        "창의관 B102호 PC실습실",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2Ffaef033a-c85d-4ff3-ae2b-cbda5380d9cd.png&w=1200&q=75",
+        "창의관 B102호 PC실습실",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    ),
+    CHANGUI_HALL_B103(
+        33,
+        "창의관 B103호 실습실",
+        "https://startup.ssu.ac.kr/_next/image?url=https%3A%2F%2Fstartup.ssu.ac.kr%2Fapi%2Fresource%2FRENTAL_ITEM_IMG%2F2023%2F06%2F563c747d-3290-42ff-95cc-0783b7f25d6f.png&w=1200&q=75",
+        "창의관 B103호 실습실",
+        "09:00 ~ 17:00 (평일)",
+        "1 ~ ",
+    );
+
+    companion object {
+        fun of(id: Int): SpaceType {
+            return entries.find { it.id == id }
+                ?: throw IllegalArgumentException("Invalid SpaceType id")
+        }
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
사용 가능한 회의실 조회에 창업지원단 공간 포함
- 외부 api 호출을 통해 선택한 날짜에 대한 모든 창업지원단 공간의 예약 정보 조회
- 조회한 예약 정보를 통해 선택한 시간에 사용 가능한 회의실만 필터링해서 반환

## 📎 Issue 번호
- closed #56 
